### PR TITLE
fix(cli): update templates to work with latest API

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -229,3 +229,37 @@ jobs:
           moon test --target wasm src/x/components/aria
           moon test --target wasm-gc src/x/components/aria
           moon test --target native src/x/components/aria
+
+  # CLI: Verify that scaffolded projects build successfully
+  test-scaffold:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - run: pnpm install
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+      - name: Build CLI
+        run: cd js/luna && pnpm tsdown bin/cli.ts --no-config --out-dir dist --format esm
+      - name: Create TypeScript project
+        run: cd ${{ runner.temp }} && node ${{ github.workspace }}/js/luna/dist/cli.mjs new test-tsx
+      - name: Build TypeScript project
+        working-directory: ${{ runner.temp }}/test-tsx
+        run: npm install && npm run build
+      - name: Create MoonBit project
+        run: cd ${{ runner.temp }} && node ${{ github.workspace }}/js/luna/dist/cli.mjs new test-mbt --mbt
+      - name: Build MoonBit project
+        working-directory: ${{ runner.temp }}/test-mbt
+        run: |
+          moon update
+          npm install 
+          npm run build

--- a/README.md
+++ b/README.md
@@ -8,13 +8,29 @@ Island Architecture-based UI library implemented in MoonBit.
 
 ## Installation
 
-```json
-// moon.mod.json
-{
-  "deps": {
-    "mizchi/luna": "0.7.0"
-  }
-}
+```sh
+moon add mizchi/luna
+```
+
+## Quick Start
+
+### TypeScript/JSX Project
+
+```sh
+npx @luna_ui/luna new myapp
+cd myapp
+npm install
+npm run dev
+```
+
+### MoonBit Project
+
+```sh
+npx @luna_ui/luna new myapp --mbt
+cd myapp
+moon update
+npm install
+npm run dev
 ```
 
 ## Packages

--- a/js/luna/bin/cli.ts
+++ b/js/luna/bin/cli.ts
@@ -203,6 +203,7 @@ export default defineConfig({
     <title>${projectName}</title>
   </head>
   <body>
+    <h1>${projectName}</h1>
     <div id="app"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
@@ -214,7 +215,7 @@ export default defineConfig({
       content: `import { render } from "@luna_ui/luna";
 import { App } from "./App";
 
-render(() => <App />, document.getElementById("app")!);
+render(document.getElementById("app")!, <App />);
 `,
     },
     {
@@ -298,8 +299,9 @@ function getMbtTemplates(projectName: string): Template[] {
           name: `internal/${projectName}`,
           version: "0.0.1",
           deps: {
-            "mizchi/luna": "0.1.3",
-            "mizchi/js": "0.10.6",
+            "mizchi/luna": "0.16.0",
+            "mizchi/signals": "0.6.3",
+            "mizchi/js": "0.10.14",
           },
           source: "src",
           "preferred-target": "js",
@@ -343,6 +345,7 @@ export default defineConfig({
     moonbit({
       watch: true,
       showLogs: true,
+      mode: "debug",
     }),
   ],
 });
@@ -378,9 +381,12 @@ import "mbt:internal/${projectName}";
           "is-main": true,
           "supported-targets": ["js"],
           import: [
-            "mizchi/luna/signal",
             {
-              path: "mizchi/luna/platform/dom/element",
+              path: "mizchi/signals",
+              alias: "signal",
+            },
+            {
+              path: "mizchi/luna/dom",
               alias: "dom",
             },
             {
@@ -403,8 +409,9 @@ import "mbt:internal/${projectName}";
       content: `// Luna Counter App
 
 fn main {
-  let count = @signal.signal(0)
+  let count = @signal.Signal::new(0)
   let doubled = @signal.memo(fn() { count.get() * 2 })
+  let items : @signal.Signal[Array[String]] = @signal.Signal::new([])
 
   let doc = @js_dom.document()
   match doc.getElementById("app") {
@@ -431,8 +438,37 @@ fn main {
             [@dom.text("Reset")],
           ),
         ]),
+        @dom.h2([@dom.text("Items")]),
+        @dom.button(
+          on=@dom.events().click(_ => {
+            let next_index = items.get().length() + 1
+            items.update(fn(prev) {
+              let arr = prev.copy()
+              arr.push("Item " + next_index.to_string())
+              arr
+            })
+          }),
+          [@dom.text("Add Item")],
+        ),
+        @dom.show(
+          fn() { items.get().length() > 0 },
+          fn() {
+            @dom.ul([
+              @dom.for_each(
+                fn() { items.get() },
+                fn(item, index) {
+                  @dom.li([@dom.text("\\{index}: \\{item}")])
+                },
+              ),
+            ])
+          },
+        ),
+        @dom.show(
+          fn() { items.get().length() == 0 },
+          fn() { @dom.p([@dom.text("No items yet")]) },
+        ),
       ])
-      @dom.render(el |> @dom.DomElement::from_jsdom, app)
+      @dom.render(el |> @dom.DomElement::from_dom, app)
     }
     None => ()
   }


### PR DESCRIPTION
## Fix
- Fix MoonBit scaffold to use the latest Signal package.
- Fix TypeScript scaffold broken by incorrect `render` argument order (`render(() => <App />, element)` -> `render(element, <App />)`)

## Improvements
- Add items list to MoonBit example app to match the TypeScript template.
- Add `test-scaffold` CI job to verify both TypeScript and MoonBit templates build successfully
- Update README with Quick Start section
