### PR TITLE
chore: bump mizchi/x to 0.2.0

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/npm_typed": "0.1.11",
     "moonbitlang/parser": "0.1.17",
     "mizchi/signals": "0.6.3",
-    "mizchi/x": "0.1.4"
+    "mizchi/x": "0.2.0"
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/luna",


### PR DESCRIPTION
## Summary
- Bump \`mizchi/x\` from 0.1.4 to 0.2.0

Note: \`moon check\` is currently broken on main due to a pre-existing
\`moonbitlang/parser\` 0.1.17 incompatibility with newer moonc (duplicate
\`Show\` impl in \`.mooncakes/moonbitlang/parser/basic/report.mbt\`).
Fixing this requires a separate parser 0.1.17 → 0.2.5 upgrade, which is
a breaking API change out of scope for this dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)