### PR TITLE
ci: cover astra/sol + add integration smoke jobs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,12 +34,8 @@ jobs:
       - run: |
           moon update
           moon install
-      - name: moon check
-        run: |
-          moon check --target js src
-          moon check --target js src/js/api
-          moon check --target js src/js/stream_renderer
-          moon check --target js src/x/stella
+      - name: moon check (workspace — luna + sol + astra)
+        run: moon check --target js
       - name: Build workspace packages
         run: |
           cd js/wcr && pnpm build
@@ -180,21 +176,10 @@ jobs:
         run: |
           mkdir -p _build/js/debug/test
           echo '{"type": "commonjs"}' > _build/js/debug/test/package.json
-      - name: moon test
-        run: |
-          # Luna core
-          moon test --target js src/js/resource
-          moon test --target js src/core/routes
-          moon test --target js src/core/render
-          moon test --target js src/core/serialize
-          # Luna DOM
-          moon test --target js src/dom/client
-          moon test --target js src/dom/static
-          # Luna JS
-          moon test --target js src/js/stream_renderer
-          moon test --target js src/js/api
-          # Stella
-          moon test --target js src/x/stella
+      - name: moon test (workspace — luna + sol + astra)
+        # moon.work members [".", "./sol", "./astra"]; this runs every
+        # test across the three packages in one pass.
+        run: moon test --target js
 
   # Cross-platform tests (non-JS targets: wasm, wasm-gc, native)
   test-xplat:

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -98,3 +98,94 @@ jobs:
         run: npx playwright install chromium --with-deps
       - name: E2E tests
         run: pnpm playwright test --config e2e/playwright.config.mts
+
+  # astra middleware Playwright + node:test build_dev_parity smoke
+  astra-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - run: pnpm install
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+      - run: |
+          moon update
+          moon install
+      - name: Build astra CLI bundle
+        run: moon build --target js --release
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+      - name: astra Playwright (dev_smoke)
+        run: cd astra && pnpm test:e2e
+
+  # sol Playwright (loader, hydration, async-streaming, etc.)
+  sol-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - run: pnpm install
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+      - run: |
+          moon update
+          moon install
+      - name: Build workspace
+        run: moon build --target js --release
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+      - name: sol Playwright
+        run: cd sol && pnpm test:e2e
+
+  # Cross-package node:test smokes (build/dev parity + examples matrix
+  # + sol cli node:tests). Faster than the Playwright runs above.
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - run: pnpm install
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+      - run: |
+          moon update
+          moon install
+      - name: Build workspace
+        run: moon build --target js --release
+      - name: Build debug for sol generate flow (sol_app/auth/todo)
+        run: moon build --target js
+      - name: Run integration smokes
+        run: pnpm test:integration
+      - name: sol cli node:tests
+        run: |
+          cd sol
+          node --test e2e/cli-golden-path.test.js
+          node --test e2e/template-check.test.js
+          node --test e2e/generate-codegen.test.js

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -123,7 +123,9 @@ jobs:
       - name: Build astra CLI bundle
         run: moon build --target js --release
       - name: Install Playwright Chromium
-        run: npx playwright install chromium --with-deps
+        # Install via astra's own pnpm context so the headless-shell
+        # cache path matches astra's @playwright/test version.
+        run: cd astra && pnpm exec playwright install chromium --with-deps
       - name: astra Playwright (dev_smoke)
         run: cd astra && pnpm test:e2e
 
@@ -151,7 +153,9 @@ jobs:
       - name: Build workspace
         run: moon build --target js --release
       - name: Install Playwright Chromium
-        run: npx playwright install chromium --with-deps
+        # Install via sol's own pnpm context so the headless-shell
+        # cache path matches sol's @playwright/test version.
+        run: cd sol && pnpm exec playwright install chromium --with-deps
       - name: sol Playwright
         run: cd sol && pnpm test:e2e
 


### PR DESCRIPTION
## Summary

After PRs #23 and #24, CI was still hand-listing luna's source paths and didn't exercise astra or sol at all. This PR:

- **Simplifies** \`check.yaml\` to use workspace-wide \`moon check\` / \`moon test\` (covers luna + sol + astra in one pass via moon.work).
- **Adds** three new jobs in \`playwright.yaml\`:
  - \`astra-e2e\` — astra Playwright (dev_smoke against \`astra/examples/sol_docs\`)
  - \`sol-e2e\` — sol Playwright (loader / hydration / async-streaming)
  - \`integration\` — \`pnpm test:integration\` (build/dev parity + 7-example matrix) + sol cli node:test files (cli-golden-path / template-check / generate-codegen)

luna's existing \`check\` / \`vitest-browser\` / \`e2e\` jobs are unchanged — the bundle-size, treeshake, runtime-bench, and moon-bench PR comments keep working.

## Test plan

CI should now run 7 jobs total (was 5):
- check (luna-specific bench / size reports)
- test-moonbit (workspace test, was per-path)
- test-xplat (luna xplat, unchanged)
- vitest-browser (luna, unchanged)
- e2e (luna Playwright, unchanged)
- **astra-e2e** (new)
- **sol-e2e** (new)
- **integration** (new)