### PR TITLE
chore: patch bump all (cmd/<name> CLI release)

### DIFF
--- a/astra/moon.mod.json
+++ b/astra/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "mizchi/astra",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "deps": {
     "mizchi/luna": "0.18.3",
     "mizchi/mars": "0.3.10",

--- a/js/astra/package.json
+++ b/js/astra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/astra",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "type": "module",
   "bin": {

--- a/js/luna/package.json
+++ b/js/luna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/luna",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Fine-grained reactive UI library for Moonbit/JS",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/sol/package.json
+++ b/js/sol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/sol",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": false,
   "type": "module",
   "bin": {

--- a/luna/moon.mod.json
+++ b/luna/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "mizchi/luna",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "deps": {
     "moonbitlang/async": "0.16.6",
     "moonbitlang/x": "0.4.40",

--- a/sol/moon.mod.json
+++ b/sol/moon.mod.json
@@ -1,11 +1,11 @@
 {
   "name": "mizchi/sol",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "deps": {
     "moonbitlang/yacc": "0.7.12",
     "mizchi/astra": {
       "path": "../astra",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     "mizchi/luna": "0.18.3",
     "moonbitlang/async": "0.17.0",


### PR DESCRIPTION
Coordinated patch bump after PR #29 (moon-installable cmd/<name> CLI entries).

| Package | From | To |
|---|---|---|
| mizchi/luna | 0.19.1 | **0.19.2** |
| mizchi/sol | 0.16.1 | **0.16.2** |
| mizchi/astra | 0.1.1 | **0.1.2** |
| @luna_ui/luna | 0.16.1 | **0.16.2** |
| @luna_ui/sol | 0.16.1 | **0.16.2** |
| @luna_ui/astra | 0.1.1 | **0.1.2** |

Inter-dep ref: sol/moon.mod.json mizchi/astra 0.1.1 → 0.1.2.

Build green, 2794/2794 tests pass.