### PR TITLE
docs: refresh READMEs (versions, CLI install via moon install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,50 +3,72 @@
 Three packages share this repository, tied together by `moon.work` and
 published independently to [mooncakes](https://mooncakes.io/):
 
-| Package | Role | Path |
-|---------|------|------|
-| [`mizchi/luna`](./luna/)        | UI primitive — VDOM, hydration, stream renderer, Island runtime | `luna/` |
-| [`mizchi/sol`](./sol/)         | Mars-based SSR framework with file-based routing                | `sol/` |
-| [`mizchi/astra`](./astra/)     | Mountable Mars middleware for static site generation            | `astra/` |
+| Package | Role | Path | Latest |
+|---------|------|------|--------|
+| [`mizchi/luna`](./luna/)    | UI primitive — VDOM, hydration, stream renderer, Island runtime | `luna/`  | 0.19.2 |
+| [`mizchi/sol`](./sol/)      | Mars-based SSR framework with file-based routing                | `sol/`   | 0.16.2 |
+| [`mizchi/astra`](./astra/)  | Mountable Mars middleware for static site generation            | `astra/` | 0.1.2  |
 
 Each package's README has the canonical usage doc.
 
-## Layout
+## Install — library
 
-- `luna/` — luna primitives (signals, render, routing, x/components)
-- `sol/` — sol SSR framework + CLI
-- `astra/` — astra SSG middleware + CLI + examples
-- `examples/` — luna-only demos (sol/astra examples live under their packages)
-
-## Install (pick one)
+Add to your `moon.mod.json`:
 
 ```jsonc
-// moon.mod.json — UI library only
-{ "deps": { "mizchi/luna": "0.18.3" } }
+// UI library only
+{ "deps": { "mizchi/luna": "0.19.2" } }
 
 // SSR framework
-{ "deps": { "mizchi/sol": "0.16.0", "mizchi/luna": "0.18.3" } }
+{ "deps": { "mizchi/sol": "0.16.2", "mizchi/luna": "0.19.2" } }
 
-// Documentation site (SSG middleware)
-{ "deps": { "mizchi/astra": "0.1.0", "mizchi/luna": "0.18.3" } }
+// Static-site middleware (mounts on a Mars Server)
+{ "deps": { "mizchi/astra": "0.1.2", "mizchi/luna": "0.19.2" } }
 ```
+
+## Install — CLI
+
+The CLIs ship as installable mooncakes binaries:
+
+```sh
+moon install mizchi/sol/cmd/sol      # → $MOON_HOME/bin/sol
+moon install mizchi/astra/cmd/astra  # → $MOON_HOME/bin/astra
+```
+
+An npm wrapper exists for users who already have node but not moon:
+
+```sh
+pnpm add -g @luna_ui/sol     # 0.16.2
+pnpm add -g @luna_ui/astra   # 0.1.2
+```
+
+## Layout
+
+- `luna/`  — luna primitives (signals, render, routing, x/components, e2e, vite/vitest configs)
+- `sol/`   — sol SSR framework + CLI (`cmd/sol`)
+- `astra/` — astra SSG middleware + CLI (`cmd/astra`)
+- `js/`    — TS bindings + npm wrappers (`@luna_ui/{luna,sol,astra,components,loader,stella,testing,wcr,wcssr}`)
+- `tests/integration/` — cross-package smoke tests
+- `docs/`, `scripts/`
 
 ## Development
 
-```bash
+```sh
 just check          # Type check workspace-wide
 just fmt            # Format
-just test-unit      # MoonBit tests (sol + astra + luna)
-just test-e2e       # Playwright e2e (sol/e2e + astra/e2e)
+just test-unit      # MoonBit tests (luna + sol + astra)
+just test-e2e       # Playwright e2e (luna + sol + astra)
+pnpm test:integration   # build/dev parity + 7-example matrix (node:test)
 ```
 
 ## Background
 
-Astra was extracted from sol in `0.16.0` to give SSG its own
-middleware-shaped surface that can mount on any Mars `Server`. The
-extraction design lives in
-`docs/superpowers/specs/2026-05-01-astra-extraction-design.md`; the
-implementation plan is in `docs/superpowers/plans/2026-05-01-astra-extraction.md`.
+This repo started as the canonical home for `mizchi/luna` only. In May 2026
+the upstream `mizchi/sol.mbt` was retired and its sources moved here, then
+SSG capability was extracted into the new `mizchi/astra` package
+(see `docs/superpowers/specs/2026-05-01-astra-extraction-design.md` and
+the implementation plan beside it). All three packages now release in
+coordinated patch bumps from this repository.
 
 ## License
 

--- a/astra/README.md
+++ b/astra/README.md
@@ -13,15 +13,25 @@ deps: mars + markdown + luna       (no edge to sol)
 
 ## Install
 
+Library:
+
 ```jsonc
 // moon.mod.json
 {
   "deps": {
-    "mizchi/astra": "0.1.0",
+    "mizchi/astra": "0.1.2",
     "mizchi/mars": "0.3.10",
-    "mizchi/luna": "0.18.3"
+    "mizchi/luna": "0.19.2"
   }
 }
+```
+
+CLI (binary):
+
+```sh
+moon install mizchi/astra/cmd/astra  # → $MOON_HOME/bin/astra
+# or via npm
+pnpm add -g @luna_ui/astra           # 0.1.2
 ```
 
 ## Quick start — mount on a Mars server

--- a/luna/README.md
+++ b/luna/README.md
@@ -1,0 +1,46 @@
+# mizchi/luna
+
+UI primitive for MoonBit / JS. Fine-grained reactive signals, VDOM,
+hydration, stream renderer, file-based routing core, and the Island
+runtime that powers `mizchi/sol` and `mizchi/astra`.
+
+```jsonc
+// moon.mod.json
+{ "deps": { "mizchi/luna": "0.19.2" } }
+```
+
+For TypeScript consumers, the JS bindings ship as
+[`@luna_ui/luna`](https://www.npmjs.com/package/@luna_ui/luna) (also at
+0.19.x) — see `../js/luna/`.
+
+## Layout
+
+- `src/` — luna source (Moon packages: signals, render, routes, dom,
+  x/components, x/css, x/stella, etc.)
+- `e2e/` — Playwright suites for the JS-side bindings
+- `experiments/` — research code (css-factorize, view_transition,
+  webcomponents_ssr, …)
+- `spec/` — design notes
+- `vite.config.ts`, `vitest.config.ts` — JS-side dev / test runners
+
+## Development
+
+From the repo root:
+
+```sh
+moon check --target js                # workspace check (luna + sol + astra)
+moon test --target js                 # workspace test
+pnpm test:browser                     # vitest browser runner
+pnpm test:e2e                         # luna's Playwright suite
+```
+
+## Sibling packages
+
+- [`mizchi/sol`](../sol/) — SSR framework on top of luna
+- [`mizchi/astra`](../astra/) — Mountable SSG middleware
+
+The monorepo overview is in [`../README.md`](../README.md).
+
+## License
+
+MIT

--- a/sol/README.md
+++ b/sol/README.md
@@ -1,18 +1,36 @@
-# Sol - SSR-first Web Framework for MoonBit
+# mizchi/sol — SSR-first web framework for MoonBit
 
 Sol is an SSR-first web framework implemented in MoonBit.
-It adopts Island Architecture, combining server-side rendering with partial client-side hydration.
+It adopts Island Architecture, combining server-side rendering with partial
+client-side hydration. Static-site generation (SSG) lives in the sibling
+[`mizchi/astra`](../astra/) package and mounts on the same Mars Server.
+
+## Install
+
+Library:
+
+```jsonc
+// moon.mod.json
+{ "deps": { "mizchi/sol": "0.16.2", "mizchi/luna": "0.19.2" } }
+```
+
+CLI (binary):
+
+```sh
+moon install mizchi/sol/cmd/sol      # → $MOON_HOME/bin/sol
+# or via npm
+pnpm add -g @luna_ui/sol             # 0.16.2
+```
 
 ## Playground
 
-`examples/sol_app/` is the development playground for Sol framework.
-Used for prototyping new features, integration testing, and implementation verification.
+`examples/sol_app/` is the development playground (run from the repo
+root after `moon build --target js --release`):
 
 ```bash
-# Start development server in playground
-cd examples/sol_app
+cd sol/examples/sol_app
 pnpm install
-just sol dev
+sol dev
 ```
 
 ## Runtime Asset Sync (Contributors)


### PR DESCRIPTION
Aligns user-facing docs with the post-#29 / #30 state.

- Root README: latest versions table, CLI install via `moon install mizchi/<pkg>/cmd/<name>`, npm wrapper alternative, layout reflects luna/ subdir + tests/integration.
- New `luna/README.md` (luna had none after PR #26 moved it into ./luna/).
- sol/README.md: install section + corrected playground path.
- astra/README.md: install section bumped to 0.1.2 + CLI install path.

js/sol and js/astra READMEs were already updated in #29.