### PR TITLE
chore: vup repair + supported_targets migration + CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,94 +1,77 @@
-# Luna UI Library
+# luna.mbt — Agent Notes
 
-MoonBitで実装されたIsland ArchitectureベースのUIライブラリ。
+Monorepo for three MoonBit packages plus their npm wrappers. Each
+mooncake publishes independently but lives and is tested together.
 
-## 関連リポジトリ
+## Layout
 
-- **Sol** (SSR/SSGフレームワーク): [mizchi/sol.mbt](https://github.com/mizchi/sol.mbt)
+| Path | Mooncake / npm | Role |
+|------|----------------|------|
+| `luna/`  | `mizchi/luna`  / `@luna_ui/luna`  | UI primitives — VDOM, hydration, stream renderer, Island runtime, signals, vite plugin |
+| `sol/`   | `mizchi/sol`   / `@luna_ui/sol`   | SSR framework over Mars (file-based routes, CLI under `sol/src/cmd/sol`) |
+| `astra/` | `mizchi/astra` / `@luna_ui/astra` | Mountable Mars middleware for SSG (CLI under `astra/src/cmd/astra`) |
 
-## ディレクトリ構成
+`moon.work` ties the three together. Workspace-wide `moon check` /
+`moon test` cover all three. `js/*` holds the npm wrappers — most are
+thin re-exports; `js/luna` is the real npm artifact (built by tsdown).
 
-```
-src/
-├── core/             # 環境非依存コア (mizchi/luna/core)
-│   ├── vnode.mbt     # VNode型定義
-│   ├── routes/       # ルート定義・マッチング
-│   ├── serialize/    # シリアライズ
-│   └── render/       # VNode → HTML レンダリング
-├── js/               # ブラウザ向けJS実装
-│   ├── resource/     # リアクティブシグナル (mizchi/luna/js/resource)
-│   └── api/          # JavaScript API エクスポート (mizchi/luna/js/api)
-├── dom/              # DOM操作、Hydration、ルーター (mizchi/luna/dom)
-├── x/                # 実験的モジュール
-│   ├── stella/       # Island埋め込み用Shard生成
-│   ├── css/          # CSS Utilities
-│   └── components/   # UIコンポーネント
-├── examples/         # サンプルコード
-└── tests/            # 統合テスト
-js/                   # NPMパッケージ
-├── luna/             # @luna_ui/luna
-└── loader/           # @luna_ui/luna-loader
-e2e/                  # Playwrightテスト
-```
+Other top-level dirs:
+- `js/` — TS bindings + npm wrappers (`@luna_ui/{luna,sol,astra,components,loader,stella,testing,wcr,wcssr}`)
+- `tests/integration/` — cross-package smoke tests (`pnpm test:integration`)
+- `website/` — monorepo docs site, built with `astra build`
+- `docs/`, `scripts/` — repo-wide notes + coverage tool
+- See root `README.md` for the public-facing story.
 
-## 開発コマンド
+CHANGELOGs are per-package: `luna/` (only this one currently has cliff
+config — `luna/cliff.toml`), `sol/CHANGELOG.md`, `astra/CHANGELOG.md`.
 
-タスク一覧は `just --list` で確認できる。
+## Commands
 
-```bash
-# 基本
-just check            # 型チェック (moon check --target js)
-just fmt              # フォーマット (moon fmt)
-just build-moon       # MoonBit ビルド
-just build-loader     # Loader ビルド (turbo経由)
+`just --list` enumerates everything. The ones an agent normally needs:
 
-# テスト
-just test-moonbit     # MoonBit ユニットテスト
-just test-vitest      # Vitest テスト (node + browser)
-just test-e2e         # E2E テスト (Playwright)
-just test-xplat       # クロスプラットフォームテスト (js, wasm, native)
-
-# CI
-just ci               # check + test-incremental + size-check
-just size             # バンドルサイズ表示
-just size-check       # バンドルサイズチェック (loader.js < 5KB)
-
-# ユーティリティ
-just luna --help      # Luna CLI (CSS utilities)
-just metrics          # メトリクス収集
-just vup patch        # バージョンアップ
+```sh
+just check          # moon check --target js (workspace-wide)
+just fmt            # moon fmt
+just test-moonbit   # moon test --target js  (must stay 2794 PASS)
+just test-vitest    # node + browser vitest (luna)
+just test-e2e       # playwright (luna)
+pnpm test:integration   # cross-package smoke (build/dev parity + 7-example matrix)
 ```
 
-## 開発ポリシー
-
-- `moon check` を通過すること
-- `moon fmt` でフォーマット統一
-- ローダーサイズは5KB以下を維持
-
-## コミットメッセージ
-
-[Conventional Commits](https://www.conventionalcommits.org/) に従う。
-
+Coordinated bumps:
+```sh
+node luna/scripts/vup.mjs --dry-run patch   # preview
+just vup patch                              # bump + per-package CHANGELOG
+just vup patch --release                    # ... + commit + per-pkg tags
 ```
-<type>(<scope>): <description>
+The script bumps all 6 manifests (`{luna,sol,astra}/moon.mod.json` +
+`js/{luna,sol,astra}/package.json`) and the sol→astra inter-dep ref.
+Tags are per-package: `luna-v<v>`, `sol-v<v>`, `astra-v<v>`.
+
+CLI installs (mooncakes):
+```sh
+moon install mizchi/sol/cmd/sol
+moon install mizchi/astra/cmd/astra
 ```
 
-| type | 用途 |
-|------|------|
-| `feat` | 新機能 |
-| `fix` | バグ修正 |
-| `docs` | ドキュメント |
-| `refactor` | リファクタリング |
-| `perf` | パフォーマンス改善 |
-| `test` | テスト追加・修正 |
-| `chore` | ビルド・CI など |
+## Conventions
 
-## テストポリシー
+- Conventional Commits (`feat`/`fix`/`refactor`/`docs`/`chore`/...).
+- English for commit messages and public docs.
+- Every package targets `js` by default (`supported_targets = "js"` —
+  use the statement form, not the deprecated `options("supported-targets": ...)`).
+- `moon check` should stay at 0 errors; warnings are tracked but not
+  gated. `moon test --target js` MUST stay at 2794 PASS.
+- Code generation: sol's `__gen__/` lives under example projects and
+  is regenerated by `sol generate`. Generators live in
+  `sol/src/cli/{server,type,hydrate}_generator.mbt` and `templates.mbt` —
+  edit them, not the generated output.
 
-テストピラミッドに基づき、可能な限り低レイヤーでテストする。
+## Test pyramid
 
-| レイヤー | ディレクトリ | 対象 |
-|---------|-------------|------|
-| MoonBit Unit | `src/**/*_test.mbt` | 純粋ロジック（DOM非依存） |
-| Vitest | `js/**/tests/*.test.ts` | DOM操作、Hydration |
-| E2E | `e2e/**/*.test.ts` | 統合テスト |
+| Layer | Where | Targets |
+|-------|-------|---------|
+| MoonBit unit | `*/src/**/*_test.mbt` | Pure logic, no DOM |
+| Vitest | `js/**/tests/*.test.ts` | DOM, hydration, browser |
+| Playwright e2e | `*/e2e/**/*.test.ts` | Full page interaction |
+| Integration | `tests/integration/`, `astra/e2e/build_dev_parity.test.js` | Cross-package smoke (`node:test`) |

--- a/astra/src/assets/moon.pkg
+++ b/astra/src/assets/moon.pkg
@@ -5,6 +5,4 @@ import {
   "mizchi/js/node/fs" @fs,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/cache/moon.pkg
+++ b/astra/src/cache/moon.pkg
@@ -8,6 +8,4 @@ import {
   "mizchi/js/core" @js,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/cli/moon.pkg
+++ b/astra/src/cli/moon.pkg
@@ -22,6 +22,4 @@ import {
   "moonbitlang/async",
 } for "test"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/cmd/astra/moon.pkg
+++ b/astra/src/cmd/astra/moon.pkg
@@ -10,5 +10,6 @@ import {
 
 options(
   "is-main": true,
-  "supported-targets": "js",
 )
+
+supported_targets = "js"

--- a/astra/src/components/moon.pkg
+++ b/astra/src/components/moon.pkg
@@ -7,6 +7,4 @@ import {
   "mizchi/js/node/path" @path,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/content/cst/moon.pkg
+++ b/astra/src/content/cst/moon.pkg
@@ -7,6 +7,4 @@ import {
   "mizchi/markdown/toc" @md_toc,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/content/markdown/moon.pkg
+++ b/astra/src/content/markdown/moon.pkg
@@ -2,6 +2,4 @@ import {
   "mizchi/luna" @luna,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/content/md_render/moon.pkg
+++ b/astra/src/content/md_render/moon.pkg
@@ -14,6 +14,4 @@ import {
   "mizchi/luna/core/render" @render,
 } for "test"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/content/shiki/moon.pkg
+++ b/astra/src/content/shiki/moon.pkg
@@ -3,6 +3,4 @@ import {
   "mizchi/syntree/highlight" @highlight,
 }
 
-options(
-  "supported-targets": "all",
-)
+supported_targets = "all"

--- a/astra/src/content/toc/moon.pkg
+++ b/astra/src/content/toc/moon.pkg
@@ -2,6 +2,4 @@ import {
   "mizchi/astra/content/markdown" @markdown,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/deploy_adapters/moon.pkg
+++ b/astra/src/deploy_adapters/moon.pkg
@@ -5,6 +5,4 @@ import {
   "mizchi/js/node/path" @path,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/env/moon.pkg
+++ b/astra/src/env/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "supported-targets": "all",
-)
+supported_targets = "all"

--- a/astra/src/fs/moon.pkg
+++ b/astra/src/fs/moon.pkg
@@ -5,6 +5,4 @@ import {
   "mizchi/astra/env" @env,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/internal/css_kit/moon.pkg
+++ b/astra/src/internal/css_kit/moon.pkg
@@ -2,6 +2,4 @@ import {
   "mizchi/astra" @astra,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/internal/json_utils/moon.pkg
+++ b/astra/src/internal/json_utils/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "supported-targets": "js + native",
-)
+supported_targets = "js + native"

--- a/astra/src/internal/utils/moon.pkg
+++ b/astra/src/internal/utils/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "supported-targets": "all",
-)
+supported_targets = "all"

--- a/astra/src/isr/moon.pkg
+++ b/astra/src/isr/moon.pkg
@@ -2,6 +2,4 @@ import {
   "moonbitlang/core/json",
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/mdx/moon.pkg
+++ b/astra/src/mdx/moon.pkg
@@ -8,6 +8,4 @@ import {
   "mizchi/markdown/toc" @md_toc,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/middleware/moon.pkg
+++ b/astra/src/middleware/moon.pkg
@@ -14,6 +14,4 @@ import {
   "moonbitlang/async",
 } for "test"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/moon.pkg
+++ b/astra/src/moon.pkg
@@ -8,6 +8,4 @@ import {
 
 warnings = "-7-unused_field"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/render/moon.pkg
+++ b/astra/src/render/moon.pkg
@@ -22,6 +22,4 @@ import {
   "mizchi/process_pool",
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/routes/moon.pkg
+++ b/astra/src/routes/moon.pkg
@@ -9,6 +9,4 @@ import {
   "mizchi/astra/fs" @fs_adapter,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/testing/moon.pkg
+++ b/astra/src/testing/moon.pkg
@@ -3,6 +3,4 @@ import {
   "moonbitlang/async/js_async" @js_async,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/tests/moon.pkg
+++ b/astra/src/tests/moon.pkg
@@ -6,6 +6,4 @@ import {
   "moonbitlang/async",
 } for "test"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/astra/src/tree/moon.pkg
+++ b/astra/src/tree/moon.pkg
@@ -3,6 +3,4 @@ import {
   "mizchi/astra/fs" @fs_adapter,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/justfile
+++ b/justfile
@@ -240,21 +240,23 @@ changelog tag:
 changelog-preview:
     git cliff --unreleased
 
-# バージョンアップ (patch/minor/major または具体的なバージョン)
-# 使用例: just vup patch, just vup 0.4.0, just vup minor --dry-run
+# バージョンアップ (patch/minor/major or 0.X.Y)
+# Bumps luna / sol / astra (moon.mod + npm wrapper) in lockstep.
+# 例: just vup patch, just vup 0.4.0, just vup patch --dry-run, just vup patch --release
 vup version *args:
     #!/usr/bin/env bash
     set -e
-    # バージョン更新
     node luna/scripts/vup.mjs {{version}} {{args}}
-    # dry-run でなければ changelog 更新
     if [[ ! " {{args}} " =~ " --dry-run " ]]; then
-        # 更新後のバージョンを取得
-        NEW_VERSION=$(node -p "require('./moon.mod.json').version")
-        echo ""
-        echo "Updating CHANGELOG.md..."
-        git cliff --tag "v${NEW_VERSION}" -o CHANGELOG.md 2>/dev/null
-        echo "  CHANGELOG.md updated for v${NEW_VERSION}"
+        # Per-package CHANGELOGs (each package owns its own version + cliff config).
+        for pkg in luna sol astra; do
+            if [[ -f "${pkg}/cliff.toml" ]]; then
+                NEW_VERSION=$(node -p "require('./${pkg}/moon.mod.json').version")
+                echo ""
+                echo "Updating ${pkg}/CHANGELOG.md..."
+                git cliff --config "${pkg}/cliff.toml" --tag "${pkg}-v${NEW_VERSION}" -o "${pkg}/CHANGELOG.md" 2>/dev/null || true
+            fi
+        done
     fi
 
 # メトリクス

--- a/luna/scripts/vup.mjs
+++ b/luna/scripts/vup.mjs
@@ -1,44 +1,61 @@
 #!/usr/bin/env node
 /**
- * Version update script for luna.mbt
+ * Monorepo version bump for luna.mbt.
  *
- * Recommended usage via just:
- *   just vup patch                 # bump + changelog
- *   just vup patch --release       # bump + changelog + commit + tag
+ * Bumps the three MoonBit packages and their npm wrappers in lockstep.
+ * Each package owns its OWN version (luna / sol / astra are independent),
+ * but a single semver bump (patch/minor/major) increments each one
+ * relative to its current value.
  *
- * Direct usage:
- *   node scripts/vup.mjs patch|minor|major [targets...] [--release] [--dry-run]
+ * Files touched (always run from the repo root):
+ *   luna/moon.mod.json
+ *   sol/moon.mod.json   (also updates the inter-dep ref `mizchi/astra.{path,version}`
+ *                        to match astra's new version)
+ *   astra/moon.mod.json
+ *   js/luna/package.json
+ *   js/sol/package.json
+ *   js/astra/package.json
  *
- * Targets: moon.mod.json, js/luna, examples
+ * Usage:
+ *   node luna/scripts/vup.mjs patch              # bump each 0.x.y -> 0.x.(y+1)
+ *   node luna/scripts/vup.mjs minor              # bump each 0.x.y -> 0.(x+1).0
+ *   node luna/scripts/vup.mjs major              # bump each 0.x.y -> (x+1).0.0
+ *   node luna/scripts/vup.mjs 0.20.0             # set ALL packages to 0.20.0
+ *   node luna/scripts/vup.mjs --dry-run patch    # preview without writing
+ *   node luna/scripts/vup.mjs patch --release    # write, commit, tag (per-package tags)
+ *   node luna/scripts/vup.mjs patch --release --push   # release then push
+ *
+ * Tags created by --release reflect each package's actual new version:
+ *   luna-v<luna_version>
+ *   sol-v<sol_version>
+ *   astra-v<astra_version>
+ *
+ * See `just vup` for the wrapper that also regenerates per-package CHANGELOGs.
  */
-import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+// vup.mjs lives at <root>/luna/scripts/vup.mjs, so root is two levels up.
 const rootDir = join(__dirname, "..", "..");
 
 // =============================================================================
-// Target definitions
+// Package definitions
 // =============================================================================
 
-const TARGETS = {
-  "moon.mod.json": {
-    getPath: () => join(rootDir, "moon.mod.json"),
-    getVersion: (json) => json.version,
-    setVersion: (json, version) => {
-      json.version = version;
-    },
-  },
-  "js/luna": {
-    getPath: () => join(rootDir, "js/luna/package.json"),
-    getVersion: (json) => json.version,
-    setVersion: (json, version) => {
-      json.version = version;
-    },
-  },
-};
+/**
+ * Each package is identified by its short id (luna / sol / astra) and has:
+ *   - moonModPath:   path to moon.mod.json
+ *   - npmPath:       path to js/<id>/package.json
+ *   - tagPrefix:     git tag prefix (e.g. "luna-v")
+ */
+const PACKAGES = [
+  { id: "luna",  moonModPath: "luna/moon.mod.json",  npmPath: "js/luna/package.json",  tagPrefix: "luna-v"  },
+  { id: "sol",   moonModPath: "sol/moon.mod.json",   npmPath: "js/sol/package.json",   tagPrefix: "sol-v"   },
+  { id: "astra", moonModPath: "astra/moon.mod.json", npmPath: "js/astra/package.json", tagPrefix: "astra-v" },
+];
 
 // =============================================================================
 // Semver helpers
@@ -55,155 +72,128 @@ function isSemverType(arg) {
 }
 
 function incrementVersion(version, type) {
-  // Remove prerelease suffix for increment
   const base = version.split("-")[0];
   const [major, minor, patch] = base.split(".").map(Number);
-
   switch (type) {
-    case "major":
-      return `${major + 1}.0.0`;
-    case "minor":
-      return `${major}.${minor + 1}.0`;
-    case "patch":
-      return `${major}.${minor}.${patch + 1}`;
-    default:
-      throw new Error(`Unknown increment type: ${type}`);
+    case "major": return `${major + 1}.0.0`;
+    case "minor": return `${major}.${minor + 1}.0`;
+    case "patch": return `${major}.${minor}.${patch + 1}`;
+    default: throw new Error(`Unknown increment type: ${type}`);
   }
 }
 
 // =============================================================================
-// File update helpers
+// File helpers
 // =============================================================================
 
-function readJsonFile(filePath) {
-  if (!existsSync(filePath)) {
-    return null;
-  }
-  const content = readFileSync(filePath, "utf-8");
-  return JSON.parse(content);
+function readJson(absPath) {
+  if (!existsSync(absPath)) throw new Error(`File not found: ${absPath}`);
+  return JSON.parse(readFileSync(absPath, "utf-8"));
 }
 
-function writeJsonFile(filePath, json, dryRun = false) {
+function writeJson(absPath, json, dryRun) {
+  const serialized = JSON.stringify(json, null, 2) + "\n";
   if (dryRun) {
-    console.log(`  [dry-run] Would write: ${filePath}`);
+    console.log(`  [dry-run] write ${absPath}`);
     return;
   }
-  writeFileSync(filePath, JSON.stringify(json, null, 2) + "\n");
-}
-
-function updateTarget(targetName, newVersion, dryRun = false) {
-  const target = TARGETS[targetName];
-  if (!target) {
-    console.error(`  Unknown target: ${targetName}`);
-    return false;
-  }
-
-  const filePath = target.getPath();
-  const json = readJsonFile(filePath);
-  if (!json) {
-    console.error(`  File not found: ${filePath}`);
-    return false;
-  }
-
-  const oldVersion = target.getVersion(json);
-  target.setVersion(json, newVersion);
-  writeJsonFile(filePath, json, dryRun);
-  console.log(`  ${targetName}: ${oldVersion} -> ${newVersion}`);
-  return true;
-}
-
-function getTargetVersion(targetName) {
-  const target = TARGETS[targetName];
-  if (!target) return null;
-
-  const json = readJsonFile(target.getPath());
-  if (!json) return null;
-
-  return target.getVersion(json);
+  writeFileSync(absPath, serialized);
 }
 
 // =============================================================================
-// Examples updater (updates dependencies, not own versions)
+// Bump planning
 // =============================================================================
 
-function updateExamples(newVersion, dryRun = false) {
-  console.log("\nUpdating examples (dependencies)...");
+/**
+ * Build a plan: { id, currentMoon, newMoon, currentNpm, newNpm } per package.
+ * For an explicit version, all six get that version.
+ * For a semver bump, each is incremented relative to its OWN current version
+ * (npm wrapper bumps relative to its own current value too — they currently
+ * mirror but this keeps that loosely coupled).
+ */
+function buildPlan(spec) {
+  return PACKAGES.map(pkg => {
+    const moonAbs = join(rootDir, pkg.moonModPath);
+    const npmAbs = join(rootDir, pkg.npmPath);
+    const moon = readJson(moonAbs);
+    const npm = readJson(npmAbs);
+    const currentMoon = moon.version;
+    const currentNpm = npm.version;
+    const newMoon = spec.kind === "explicit"
+      ? spec.version
+      : incrementVersion(currentMoon, spec.kind);
+    const newNpm = spec.kind === "explicit"
+      ? spec.version
+      : incrementVersion(currentNpm, spec.kind);
+    return {
+      ...pkg,
+      moonAbs, npmAbs,
+      moon, npm,
+      currentMoon, newMoon,
+      currentNpm, newNpm,
+    };
+  });
+}
 
-  const examplesDir = join(rootDir, "examples");
-  if (!existsSync(examplesDir)) {
-    console.log("  No examples directory found");
-    return;
-  }
+function applyPlan(plan, dryRun) {
+  // First: figure out astra's new version so sol's inter-dep ref can be updated.
+  const astraEntry = plan.find(p => p.id === "astra");
+  const astraNewVersion = astraEntry?.newMoon;
 
-  const examples = readdirSync(examplesDir, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .map((d) => d.name);
+  for (const entry of plan) {
+    // Update moon.mod.json own version.
+    entry.moon.version = entry.newMoon;
 
-  for (const example of examples) {
-    // Update moon.mod.json (mizchi/luna dependency)
-    const moonModPath = join(examplesDir, example, "moon.mod.json");
-    const moonJson = readJsonFile(moonModPath);
-    if (moonJson?.deps?.["mizchi/luna"]) {
-      const dep = moonJson.deps["mizchi/luna"];
-      if (typeof dep === "string") {
-        const oldVersion = dep;
-        moonJson.deps["mizchi/luna"] = newVersion;
-        writeJsonFile(moonModPath, moonJson, dryRun);
-        console.log(`  ${example}/moon.mod.json: mizchi/luna ${oldVersion} -> ${newVersion}`);
-      } else if (typeof dep === "object" && dep.version) {
-        const oldVersion = dep.version;
-        dep.version = newVersion;
-        writeJsonFile(moonModPath, moonJson, dryRun);
-        console.log(`  ${example}/moon.mod.json: mizchi/luna ${oldVersion} -> ${newVersion}`);
+    // Special-case sol: bump the inter-package ref to astra.
+    if (entry.id === "sol" && astraNewVersion && entry.moon.deps?.["mizchi/astra"]) {
+      const dep = entry.moon.deps["mizchi/astra"];
+      if (typeof dep === "object" && dep !== null) {
+        const oldRef = dep.version;
+        dep.version = astraNewVersion;
+        // path stays as-is; only version field gets bumped.
+        console.log(`  sol/moon.mod.json: deps.mizchi/astra.version ${oldRef} -> ${astraNewVersion}`);
+      } else if (typeof dep === "string") {
+        console.log(`  sol/moon.mod.json: deps.mizchi/astra ${dep} -> ${astraNewVersion}`);
+        entry.moon.deps["mizchi/astra"] = astraNewVersion;
       }
     }
 
-    // Update package.json (@luna_ui/* dependencies)
-    const pkgJsonPath = join(examplesDir, example, "package.json");
-    const pkgJson = readJsonFile(pkgJsonPath);
-    if (pkgJson) {
-      let updated = false;
-      for (const depType of ["dependencies", "devDependencies"]) {
-        if (pkgJson[depType]) {
-          for (const [dep, ver] of Object.entries(pkgJson[depType])) {
-            if (dep.startsWith("@luna_ui/")) {
-              pkgJson[depType][dep] = newVersion;
-              console.log(`  ${example}/package.json: ${dep} -> ${newVersion}`);
-              updated = true;
-            }
-          }
-        }
-      }
-      if (updated) {
-        writeJsonFile(pkgJsonPath, pkgJson, dryRun);
-      }
-    }
+    writeJson(entry.moonAbs, entry.moon, dryRun);
+    console.log(`  ${entry.moonModPath}: ${entry.currentMoon} -> ${entry.newMoon}`);
+
+    entry.npm.version = entry.newNpm;
+    writeJson(entry.npmAbs, entry.npm, dryRun);
+    console.log(`  ${entry.npmPath}: ${entry.currentNpm} -> ${entry.newNpm}`);
   }
 }
 
 // =============================================================================
-// Git & Release helpers
+// Git helpers
 // =============================================================================
 
-function exec(cmd, dryRun = false) {
+function exec(cmd, dryRun) {
   if (dryRun) {
-    console.log(`  [dry-run] Would run: ${cmd}`);
+    console.log(`  [dry-run] $ ${cmd}`);
     return "";
   }
   console.log(`  $ ${cmd}`);
   return execSync(cmd, { cwd: rootDir, encoding: "utf-8", stdio: "pipe" });
 }
 
-function gitCommit(version, dryRun = false) {
-  console.log("\nCommitting changes...");
+function release(plan, kind, dryRun, doPush) {
+  console.log("\nReleasing...");
   exec("git add -A", dryRun);
-  exec(`git commit -m "chore: v${version}"`, dryRun);
-}
-
-function gitTag(version, dryRun = false) {
-  console.log("\nCreating git tag...");
-  exec(`git tag v${version}`, dryRun);
-  console.log(`  Created tag: v${version}`);
+  const kindLabel = kind === "explicit" ? "set version" : `bump ${kind}`;
+  exec(`git commit -m "chore: ${kindLabel} all packages"`, dryRun);
+  for (const entry of plan) {
+    exec(`git tag ${entry.tagPrefix}${entry.newMoon}`, dryRun);
+  }
+  if (doPush) {
+    exec("git push", dryRun);
+    exec("git push --tags", dryRun);
+  } else {
+    console.log("\n  (skip push — pass --push to push branch and tags)");
+  }
 }
 
 // =============================================================================
@@ -212,127 +202,69 @@ function gitTag(version, dryRun = false) {
 
 function printUsage() {
   console.log(`Usage:
-  node scripts/vup.mjs <version>                      # Update all targets
-  node scripts/vup.mjs <version> <targets...>         # Update specific targets
-  node scripts/vup.mjs patch|minor|major              # Increment all targets
-  node scripts/vup.mjs patch|minor|major <targets...> # Increment specific targets
+  node luna/scripts/vup.mjs patch|minor|major [--dry-run] [--release [--push]]
+  node luna/scripts/vup.mjs <X.Y.Z>            [--dry-run] [--release [--push]]
 
-Options:
-  --release    Commit and tag (use with 'just vup' for changelog)
-  --dry-run    Show what would be done without making changes
-  --help, -h   Show this help
+Touches all 6 manifests:
+  luna/moon.mod.json, sol/moon.mod.json, astra/moon.mod.json,
+  js/luna/package.json, js/sol/package.json, js/astra/package.json
+  (sol/moon.mod.json deps.mizchi/astra.version is also bumped to match astra)
 
-Targets:
-  moon.mod.json  - Root MoonBit module
-  js/luna        - @luna_ui/luna package
-  examples       - All example projects (dependencies only)
+Tags created by --release: luna-v<v>, sol-v<v>, astra-v<v>.
 
 Examples:
-  just vup patch                            # Recommended: bump + changelog
-  just vup patch --release                  # bump + changelog + commit + tag
-  node scripts/vup.mjs 0.4.0 js/luna        # Update specific target only`);
+  node luna/scripts/vup.mjs --dry-run patch         # preview
+  node luna/scripts/vup.mjs patch                   # bump each package
+  node luna/scripts/vup.mjs 0.20.0                  # set all to 0.20.0
+  node luna/scripts/vup.mjs patch --release         # bump + commit + per-pkg tags
+  node luna/scripts/vup.mjs patch --release --push  # ... and push
+`);
 }
 
 function main() {
-  const args = process.argv.slice(2);
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes("--dry-run");
+  const doRelease = argv.includes("--release");
+  const doPush = argv.includes("--push");
+  const showHelp = argv.includes("--help") || argv.includes("-h");
+  const positional = argv.filter(a => !a.startsWith("--") && a !== "-h");
 
-  // Parse flags
-  const doRelease = args.includes("--release");
-  const dryRun = args.includes("--dry-run");
-  const showHelp = args.includes("--help") || args.includes("-h");
-
-  // Remove flags from args
-  const positionalArgs = args.filter(
-    (a) => !a.startsWith("--") && a !== "-h"
-  );
-
-  if (positionalArgs.length === 0 || showHelp) {
+  if (showHelp || positional.length === 0) {
     printUsage();
-    process.exit(positionalArgs.length === 0 && !showHelp ? 1 : 0);
+    process.exit(showHelp ? 0 : 1);
   }
-
-  if (dryRun) {
-    console.log("[DRY RUN MODE - No changes will be made]\n");
-  }
-
-  const firstArg = positionalArgs[0];
-  const restArgs = positionalArgs.slice(1);
-
-  // Determine if first arg is version or semver type
-  const isSemver = isSemverType(firstArg);
-  const isVersion = isValidVersion(firstArg);
-
-  if (!isSemver && !isVersion) {
-    console.error(`Invalid version or semver type: ${firstArg}`);
-    console.error("Expected: X.Y.Z, X.Y.Z-suffix, or patch|minor|major");
+  if (positional.length > 1) {
+    console.error(`Unexpected extra args: ${positional.slice(1).join(" ")}`);
+    printUsage();
     process.exit(1);
   }
 
-  // Determine targets
-  let targetNames = restArgs.length > 0 ? restArgs : Object.keys(TARGETS);
-
-  // Validate targets
-  const includesExamples = targetNames.includes("examples");
-  targetNames = targetNames.filter((t) => t !== "examples");
-
-  for (const t of targetNames) {
-    if (!TARGETS[t]) {
-      console.error(`Unknown target: ${t}`);
-      console.error(`Available targets: ${Object.keys(TARGETS).join(", ")}, examples`);
-      process.exit(1);
-    }
-  }
-
-  // Calculate final version for display
-  let finalVersion;
-  if (isSemver) {
-    const currentVersion = getTargetVersion("moon.mod.json");
-    finalVersion = incrementVersion(currentVersion, firstArg);
+  const arg = positional[0];
+  let spec;
+  if (isSemverType(arg)) {
+    spec = { kind: arg };
+  } else if (isValidVersion(arg)) {
+    spec = { kind: "explicit", version: arg };
   } else {
-    finalVersion = firstArg;
+    console.error(`Invalid argument: ${arg}`);
+    console.error("Expected: patch | minor | major | X.Y.Z");
+    process.exit(1);
   }
 
-  // Process each target
-  console.log(`Updating targets: ${[...targetNames, ...(includesExamples ? ["examples"] : [])].join(", ")}`);
-  console.log(`New version: ${finalVersion}\n`);
+  if (dryRun) console.log("[DRY RUN — no files written]\n");
 
-  for (const targetName of targetNames) {
-    let newVersion;
+  console.log(`Plan (${spec.kind === "explicit" ? `set ${spec.version}` : `${spec.kind} bump`}):`);
+  const plan = buildPlan(spec);
+  applyPlan(plan, dryRun);
 
-    if (isSemver) {
-      // Get current version and increment
-      const currentVersion = getTargetVersion(targetName);
-      if (!currentVersion) {
-        console.error(`  Cannot get current version for: ${targetName}`);
-        continue;
-      }
-      newVersion = incrementVersion(currentVersion, firstArg);
-    } else {
-      newVersion = firstArg;
-    }
-
-    updateTarget(targetName, newVersion, dryRun);
-  }
-
-  // Update examples if specified or if updating all
-  if (includesExamples || restArgs.length === 0) {
-    // Re-read to get updated version if we just updated it
-    const actualVersion = dryRun ? finalVersion : getTargetVersion("moon.mod.json");
-    updateExamples(actualVersion, dryRun);
-  }
-
-  // Release workflow (commit + tag only, changelog is handled by justfile)
   if (doRelease) {
-    gitCommit(finalVersion, dryRun);
-    gitTag(finalVersion, dryRun);
+    release(plan, spec.kind, dryRun, doPush);
+  }
 
-    console.log("\nRelease complete!");
-    console.log(`\nNext steps:`);
-    console.log(`  1. Push: git push && git push --tags`);
-    console.log(`  2. Publish to mooncakes: moon publish`);
-    console.log(`  3. Publish to npm: cd js/luna && pnpm publish --access public`);
-  } else {
-    console.log("\nDone!");
+  console.log("\nDone.");
+  if (!doRelease) {
+    console.log("Next: review diff, regenerate per-package CHANGELOGs, then commit/tag manually");
+    console.log("      or re-run with --release.");
   }
 }
 

--- a/sol/e2e/mbt_e2e/src/moon.pkg
+++ b/sol/e2e/mbt_e2e/src/moon.pkg
@@ -6,5 +6,6 @@ import {
 
 options(
   "is-main": true,
-  "supported-targets": "js",
 )
+
+supported_targets = "js"

--- a/sol/examples/sol_api/app/server/moon.pkg
+++ b/sol/examples/sol_api/app/server/moon.pkg
@@ -7,7 +7,8 @@ import {
 
 options(
   "is-main": true,
-  "supported-targets": "js",
   "warn-list": "-35-67-29",
   link: { "js": { "format": "esm" } },
 )
+
+supported_targets = "js"

--- a/sol/src/action/moon.pkg
+++ b/sol/src/action/moon.pkg
@@ -7,6 +7,4 @@ import {
 
 warnings = "-6"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/bench_js_api/moon.pkg
+++ b/sol/src/bench_js_api/moon.pkg
@@ -6,6 +6,7 @@ import {
 
 options(
   "is-main": true,
-  "supported-targets": "js",
   link: { "js": { "format": "esm" } },
 )
+
+supported_targets = "js"

--- a/sol/src/bench_native_api/moon.pkg
+++ b/sol/src/bench_native_api/moon.pkg
@@ -6,5 +6,6 @@ import {
 
 options(
   "is-main": true,
-  "supported-targets": "native",
 )
+
+supported_targets = "native"

--- a/sol/src/builder/moon.pkg
+++ b/sol/src/builder/moon.pkg
@@ -3,6 +3,4 @@ import {
   "mizchi/js/node/child_process" @child_process,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/builder_pool/moon.pkg
+++ b/sol/src/builder_pool/moon.pkg
@@ -7,6 +7,4 @@ import {
   "mizchi/astra/content/shiki" @shiki,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/cli/generate.mbt
+++ b/sol/src/cli/generate.mbt
@@ -196,7 +196,7 @@ async fn[FS : @env.FileSystem] run_generate_command_with_fs(
       try {
         fs.write_file_sync(stub_types_mbt_path, "///| No Props types found\n")
         fs.write_file_sync(
-          stub_types_pkg_path, "options(\n  \"supported-targets\": \"js\",\n  \"warn-list\": \"-29\",\n)\n",
+          stub_types_pkg_path, "supported_targets = \"js\"\n\noptions(\n  \"warn-list\": \"-29\",\n)\n",
         )
       } catch {
         e => {

--- a/sol/src/cli/hydrate_generator.mbt
+++ b/sol/src/cli/hydrate_generator.mbt
@@ -124,8 +124,8 @@ fn generate_client_gen_pkg(
     buf.write_string("  \"\{pkg_path}\" @\{pkg_alias},\n")
   }
   buf.write_string("}\n\n")
+  buf.write_string("supported_targets = \"js\"\n\n")
   buf.write_string("options(\n")
-  buf.write_string("  \"supported-targets\": \"js\",\n")
   let exports_str = exports.map(fn(n) { "\"\{n}\"" }).join(", ")
   buf.write_string(
     "  link: { \"js\": { \"exports\": [ \{exports_str} ], \"format\": \"esm\" } },\n",

--- a/sol/src/cli/moon.pkg
+++ b/sol/src/cli/moon.pkg
@@ -32,6 +32,4 @@ import {
 
 warnings = "-27-20"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/cli/server_generator.mbt
+++ b/sol/src/cli/server_generator.mbt
@@ -91,12 +91,12 @@ fn generate_server_pkg(routes_pkg : String) -> String {
   buf.write_string("}\n\n")
   buf.write_string("options(\n")
   buf.write_string("  \"is-main\": true,\n")
-  buf.write_string("  \"supported-targets\": \"js\",\n")
   buf.write_string("  \"warn-list\": \"-29\",\n")
   buf.write_string(
     "  link: { \"js\": { \"exports\": [ \"configure_app\" ], \"format\": \"esm\" } },\n",
   )
-  buf.write_string(")\n")
+  buf.write_string(")\n\n")
+  buf.write_string("supported_targets = \"js\"\n")
   buf.to_string()
 }
 

--- a/sol/src/cli/templates.mbt
+++ b/sol/src/cli/templates.mbt
@@ -163,8 +163,9 @@ pub fn template_layout_moon_pkg() -> String {
     #|  "mizchi/luna/dom/static" @server_dom,
     #|}
     #|
+    #|supported_targets = "js"
+    #|
     #|options(
-    #|  "supported-targets": "js",
     #|  "warn-list": "-24",
     #|)
   )
@@ -276,9 +277,10 @@ pub fn template_routes_moon_pkg(package_name : String) -> String {
     #|  "moonbitlang/async",
     #|}
     #|
+    #|supported_targets = "js"
+    #|
     #|options(
     #|  "is-main": true,
-    #|  "supported-targets": "js",
     #|  "warn-list": "-67-29",
     #|  link: { "js": { "format": "esm" } },
     #|)
@@ -355,8 +357,9 @@ pub fn template_client_counter_moon_pkg() -> String {
     #|  "mizchi/signals" @signal,
     #|}
     #|
+    #|supported_targets = "js"
+    #|
     #|options(
-    #|  "supported-targets": "js",
     #|  link: { "js": { "exports": [ "counter" ], "format": "esm" } },
     #|)
   )
@@ -376,8 +379,9 @@ pub fn template_gen_types_moon_pkg() -> String {
     #|  "mizchi/luna" @luna,
     #|}
     #|
+    #|supported_targets = "js"
+    #|
     #|options(
-    #|  "supported-targets": "js",
     #|  link: { "js": { "exports": [ "CounterProps", "counter" ], "format": "esm" } },
     #|)
   )
@@ -481,7 +485,7 @@ pub fn generate_doc_templates(
     { path: "sol.config.json", content: sol_config },
     {
       path: "app/server/moon.pkg",
-      content: "import {\n  \"mizchi/sol\" @sol,\n  \"moonbitlang/async\",\n}\n\noptions(\n  \"is-main\": true,\n  \"supported-targets\": \"js\",\n  \"warn-list\": \"-67-29\",\n  link: { \"js\": { \"format\": \"esm\" } },\n)",
+      content: "import {\n  \"mizchi/sol\" @sol,\n  \"moonbitlang/async\",\n}\n\nsupported_targets = \"js\"\n\noptions(\n  \"is-main\": true,\n  \"warn-list\": \"-67-29\",\n  link: { \"js\": { \"format\": \"esm\" } },\n)",
     },
     {
       path: "app/server/main.mbt",

--- a/sol/src/cli/type_generator.mbt
+++ b/sol/src/cli/type_generator.mbt
@@ -224,8 +224,8 @@ fn generate_types_pkg(
     buf.write_string("  \"mizchi/sol/action\" @action,\n")
   }
   buf.write_string("}\n\n")
+  buf.write_string("supported_targets = \"js\"\n\n")
   buf.write_string("options(\n")
-  buf.write_string("  \"supported-targets\": \"js\",\n")
   buf.write_string("  \"warn-list\": \"-29\",\n")
   // Export all struct names and factory functions
   let exports : Array[String] = []

--- a/sol/src/cli_common/moon.pkg
+++ b/sol/src/cli_common/moon.pkg
@@ -5,6 +5,4 @@ import {
   "mizchi/js/node/path" @path,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/cmd/sol/moon.pkg
+++ b/sol/src/cmd/sol/moon.pkg
@@ -10,5 +10,6 @@ import {
 
 options(
   "is-main": true,
-  "supported-targets": "js",
 )
+
+supported_targets = "js"

--- a/sol/src/hmr/moon.pkg
+++ b/sol/src/hmr/moon.pkg
@@ -4,6 +4,4 @@ import {
   "mizchi/sol/cli_common" @cli_common,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/hot_reload/moon.pkg
+++ b/sol/src/hot_reload/moon.pkg
@@ -2,6 +2,4 @@ import {
   "moonbitlang/core/strconv",
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/internal/js_any/moon.pkg
+++ b/sol/src/internal/js_any/moon.pkg
@@ -2,6 +2,4 @@ import {
   "mizchi/js/core" @js,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/internal/json_utils/moon.pkg
+++ b/sol/src/internal/json_utils/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "supported-targets": "js + native",
-)
+supported_targets = "js + native"

--- a/sol/src/internal/mars_response/moon.pkg
+++ b/sol/src/internal/mars_response/moon.pkg
@@ -3,6 +3,4 @@ import {
   "mizchi/js/core" @js,
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/internal/page_shell/moon.pkg
+++ b/sol/src/internal/page_shell/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "supported-targets": "all",
-)
+supported_targets = "all"

--- a/sol/src/internal/utils/moon.pkg
+++ b/sol/src/internal/utils/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "supported-targets": "all",
-)
+supported_targets = "all"

--- a/sol/src/isr/moon.pkg
+++ b/sol/src/isr/moon.pkg
@@ -11,6 +11,4 @@ import {
   "moonbitlang/async",
 } for "wbtest"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/middleware/moon.pkg
+++ b/sol/src/middleware/moon.pkg
@@ -5,6 +5,4 @@ import {
 
 warnings = "-6"
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/moon.pkg
+++ b/sol/src/moon.pkg
@@ -16,6 +16,4 @@ import {
   "moonbitlang/async/io",
 }
 
-options(
-  "supported-targets": "js",
-)
+supported_targets = "js"

--- a/sol/src/router/moon.pkg
+++ b/sol/src/router/moon.pkg
@@ -27,10 +27,11 @@ import {
 warnings = "-24-67-29"
 
 options(
-  "supported-targets": "js",
   targets: {
     "sol_routes_ffi_js.mbt": [ "js" ],
     "route_registration_js.mbt": [ "js" ],
     "route_params_js.mbt": [ "js" ],
   },
 )
+
+supported_targets = "js"

--- a/sol/src/tests/e2e_server/moon.pkg
+++ b/sol/src/tests/e2e_server/moon.pkg
@@ -13,5 +13,6 @@ options(
       "format": "esm",
     },
   },
-  "supported-targets": "js",
 )
+
+supported_targets = "js"

--- a/sol/src/worker/moon.pkg
+++ b/sol/src/worker/moon.pkg
@@ -5,5 +5,6 @@ import {
 options(
   "is-main": true,
   link: { "js": { "format": "esm" } },
-  "supported-targets": "js",
 )
+
+supported_targets = "js"


### PR DESCRIPTION
Three independent cleanups, one commit each.

## 1. `chore(scripts): rewrite vup.mjs for monorepo layout` (d72d5e63)

The old `luna/scripts/vup.mjs` still assumed a single root `moon.mod.json`
and one `js/luna` package — that layout was retired when sol and astra
moved into this repo. Rewritten so a single bump touches all six
manifests in lockstep while letting each mooncake own its own version
number:

- `{luna,sol,astra}/moon.mod.json` + `js/{luna,sol,astra}/package.json`
- Bumps the sol→astra inter-dep ref `deps.mizchi/astra.version` whenever astra moves
- `--release` creates per-package tags (`luna-v<v>`, `sol-v<v>`, `astra-v<v>`)
- `just vup` recipe updated to drive per-package CHANGELOGs (the old root `CHANGELOG.md` no longer exists)

Smoke-tested via `node luna/scripts/vup.mjs --dry-run patch`.

## 2. `chore(moon.pkg): migrate options(supported-targets) -> supported_targets` (33498d81)

`moon check` flagged 46 deprecation warnings for the old PKG-syntax
`options("supported-targets": ...)` form. Migrated 57 `moon.pkg` files
across `luna/`, `sol/`, `astra/` (incl. `__gen__/` scaffolds so the
next regeneration stays in sync). Also updated sol's generators
(`server_generator`, `type_generator`, `hydrate_generator`, `generate`,
`templates`) so `sol generate` and project-init templates emit the new
form going forward.

`moon.pkg.json` files are unchanged — the deprecation only applies to
the .pkg statement form. Vendored `.mooncakes/` and `_build/` skipped.

## 3. `docs(claude): rewrite CLAUDE.md for monorepo layout` (8be2dee2)

Previous CLAUDE.md described the luna-only layout. Rewritten to cover
all three packages under `moon.work`, the npm wrappers, the
`moon install mizchi/<pkg>/cmd/<name>` CLI install pattern,
`pnpm test:integration`, per-package CHANGELOGs, and the new vup flow.
AGENTS.md is a symlink so it picks up the same content.

## Verification

```
$ moon check --target js | tail -1
Finished. moon: ran 34 tasks, now up to date (594 warnings, 0 errors)
$ moon test --target js | tail -1
Total tests: 2794, passed: 2794, failed: 0.
$ node luna/scripts/vup.mjs --dry-run patch
Plan (patch bump):
  ... 6 file edits previewed ...
```

Note on the 594 figure: the supported-targets category went from 46 → 0
(verifiable via `moon check 2>&1 | grep -c supported-targets`), but the
total stayed at 594 because the migration unblocked `moon check` so it
finishes more packages and surfaces more code-level deprecations
(`derive(Show)` count went from 18 → 457). Those are an existing
backlog tracked by warning code 0027, not anything this PR introduced.

## Test plan

- [x] `moon check --target js` — 0 errors, 0 supported-targets warnings
- [x] `moon test --target js` — 2794 PASS / 0 FAIL
- [x] `node luna/scripts/vup.mjs --dry-run patch` — previews 6 file edits
- [x] `node luna/scripts/vup.mjs --dry-run 0.20.0` — previews explicit-version path
- [x] `node luna/scripts/vup.mjs --dry-run minor` — previews per-package independent bump