### PR TITLE
chore: set up release-please + OIDC publishing for js/* packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: publish
+
+# Triggered by the GitHub Releases that release-please creates.
+# Each release-please-managed package gets its own Release whose tag is
+# "@luna_ui/<pkg>-v<version>" (because include-component-in-tag is true in
+# release-please-config.json). This workflow runs once per Release event,
+# resolves the tag back to a workspace directory, and runs `npm publish`
+# from there with OIDC Trusted Publishing.
+#
+# Prerequisites (see docs/internal/npm-release-onboarding.md):
+#   - Each @luna_ui/* package has a Trusted Publisher entry on npmjs.com
+#     pointing at this repo + workflow filename "publish.yml".
+#   - npm 2FA on each package is set to "Authorization only" (NOT
+#     "Authorization and writes"), otherwise OIDC publish is rejected.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write  # required for OIDC Trusted Publishing
+
+jobs:
+  publish-monorepo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: pnpm
+
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+
+      - run: moon update
+
+      - run: pnpm install --frozen-lockfile
+
+      # Workspace-wide build is the safest bet — most js/* packages have a
+      # build step that produces dist/ and we don't want to maintain a
+      # per-package matrix here.
+      - run: pnpm -r build
+
+      # release-please tag format is "@luna_ui/<pkg>-v<version>".
+      # Strip the "-v<version>" suffix to recover the npm name, then walk
+      # js/*/package.json to find the matching directory.
+      - name: Resolve package directory from tag
+        id: pkg
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          NAME="${TAG%-v*}"
+          DIR=""
+          for f in js/*/package.json; do
+            PKG_NAME=$(node -p "require('./${f}').name")
+            if [ "$PKG_NAME" = "$NAME" ]; then
+              DIR=$(dirname "$f")
+              break
+            fi
+          done
+          if [ -z "$DIR" ]; then
+            echo "::error::No package.json under js/* matches name '$NAME' (tag '$TAG')"
+            exit 1
+          fi
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "dir=$DIR"   >> "$GITHUB_OUTPUT"
+
+      - name: Publish ${{ steps.pkg.outputs.name }}
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        # --provenance is auto-attached by npm 11+ in OIDC environments;
+        # explicitly opting in here keeps it on for older npm too.
+        # Do NOT set NPM_TOKEN — its presence disables the OIDC code path.
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,48 @@
+name: release-please
+
+# Two triggers:
+# 1. workflow_dispatch: maintainer runs this to create a Release PR
+#    (CHANGELOG is auto-generated from accumulated Conventional Commits).
+# 2. pull_request closed on main with head.ref starting with
+#    "release-please--": fires automatically after merging the Release PR
+#    so release-please itself creates the tag and GitHub Release without
+#    requiring a second manual dispatch.
+#
+# Regular feat:/fix: PR merges do NOT start this workflow — the job-level
+# `if` guard ensures only Release PR merges trigger tag creation.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# GITHUB_TOKEN is not handed to release-please. A dedicated GitHub App token
+# is used instead so the repo-wide "Allow GitHub Actions to create and approve
+# pull requests" setting can stay off.
+permissions:
+  contents: read
+
+jobs:
+  release-please:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.pull_request.merged == true &&
+         startsWith(github.event.pull_request.head.ref, 'release-please--'))
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          # App ID is safe to commit (cannot do anything by itself).
+          # The matching private key (full PEM with BEGIN/END lines) lives
+          # in the repo secret RELEASE_PLEASE_APP_PRIVATE_KEY.
+          app-id: 3420845
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,11 @@
+{
+  "js/luna": "0.16.3",
+  "js/sol": "0.16.2",
+  "js/astra": "0.1.2",
+  "js/components": "0.1.0",
+  "js/loader": "0.3.1",
+  "js/stella": "0.3.1",
+  "js/testing": "0.1.0",
+  "js/wcr": "0.3.1",
+  "js/wcssr": "0.3.1"
+}

--- a/docs/internal/npm-release-onboarding.md
+++ b/docs/internal/npm-release-onboarding.md
@@ -1,0 +1,162 @@
+# npm Release Onboarding
+
+Setup steps the maintainer must complete **once** before
+`.github/workflows/release-please.yml` and
+`.github/workflows/publish.yml` can actually publish anything.
+
+The two workflows together handle:
+- release-please proposes a "chore: release X" PR aggregating Conventional
+  Commits across `js/*` packages.
+- Merging that PR creates per-package GitHub Releases tagged
+  `@luna_ui/<pkg>-v<version>`.
+- `publish.yml` reacts to each Release event and runs `npm publish` from
+  the matching `js/<pkg>` directory using OIDC Trusted Publishing
+  (no NPM_TOKEN needed).
+
+Scope: 9 packages — `@luna_ui/{luna,sol,astra,components,luna-loader,stella,testing,wcr,wcssr}`.
+
+The 3 mooncakes packages (`mizchi/{luna,sol,astra}` MoonBit modules) stay
+on the existing `luna/scripts/vup.mjs` flow and are out of scope here.
+
+---
+
+## 1. GitHub App private key secret
+
+We use the existing `mizchi-release-please` GitHub App (app-id `3420845`)
+so release-please can open PRs without granting "Allow GitHub Actions to
+create and approve pull requests" repo-wide.
+
+1. Visit <https://github.com/settings/installations> → `mizchi-release-please`.
+2. **Configure** → Repository access → either **All repositories**, or
+   **Only select repositories** with `luna.mbt` added.
+3. Generate (or fetch a previously generated) **private key** PEM.
+   - GitHub App settings → Private keys → "Generate a private key" yields
+     a `.pem` download.
+4. Store the **full PEM** (BEGIN/END lines included, NOT base64-encoded)
+   as a repo secret:
+
+   ```sh
+   gh secret set RELEASE_PLEASE_APP_PRIVATE_KEY \
+     --repo mizchi/luna.mbt \
+     --body "$(cat ~/Downloads/mizchi-release-please.<timestamp>.private-key.pem)"
+   ```
+
+   Or via the web UI: Settings → Secrets and variables → Actions → New
+   repository secret → name `RELEASE_PLEASE_APP_PRIVATE_KEY`.
+
+---
+
+## 2. npm Trusted Publisher registration (per package, 9×)
+
+OIDC Trusted Publishing replaces NPM_TOKEN. Each package must be told
+which GitHub workflow is allowed to publish it.
+
+For **each** of the 9 packages below:
+
+1. Sign in at <https://www.npmjs.com>.
+2. Go to the package page → **Settings** → **Trusted Publisher** → **Add**.
+3. Fill in:
+   - Provider: **GitHub Actions**
+   - Organization or user: `mizchi`
+   - Repository: `luna.mbt`
+   - Workflow filename: `publish.yml` (filename only — no path, no `.github/workflows/` prefix)
+   - Environment name: leave **empty** (we don't gate via GitHub Environments)
+
+Packages:
+
+- `@luna_ui/luna`
+- `@luna_ui/sol`
+- `@luna_ui/astra`
+- `@luna_ui/components`
+- `@luna_ui/luna-loader`
+- `@luna_ui/stella`
+- `@luna_ui/testing`
+- `@luna_ui/wcr`
+- `@luna_ui/wcssr`
+
+---
+
+## 3. First-time publish (claim the names)
+
+Trusted Publisher cannot be configured for a package that doesn't exist
+yet on npm. Packages that have never been published need ONE manual
+publish from a local machine to claim the name. After that, OIDC takes
+over for subsequent releases.
+
+Check current state:
+
+```sh
+for pkg in luna sol astra components luna-loader stella testing wcr wcssr; do
+  printf '%s: ' "@luna_ui/${pkg}"
+  npm view "@luna_ui/${pkg}" version 2>/dev/null || echo '(not published)'
+done
+```
+
+For each `(not published)` package, from the package directory:
+
+```sh
+cd js/<pkg>
+pnpm install
+pnpm -r build           # build deps
+npm publish --provenance --access public
+```
+
+(Use `npm publish` not `pnpm publish` — Trusted Publishing requires
+npm 11+ which currently provides the OIDC token exchange.)
+
+Per the table baked into `release-please-config.json`, at the time of
+this doc the packages most likely needing first-claim are:
+`@luna_ui/sol`, `@luna_ui/astra`, possibly `@luna_ui/components` and
+`@luna_ui/testing`. Verify with the loop above.
+
+---
+
+## 4. npm 2FA setting
+
+OIDC publish is rejected when a package has 2FA set to "Authorization
+and writes". Switch each package's 2FA to **"Authorization only"**.
+
+Per package on npmjs.com → Settings → Require two-factor authentication
+→ choose **Authorization only**.
+
+(Account-level 2FA stays as-is — this is a per-package setting.)
+
+---
+
+## 5. First release dry-run
+
+Once secret + Trusted Publishers + 2FA are set:
+
+```sh
+gh workflow run release-please.yml --repo mizchi/luna.mbt
+```
+
+This creates a "chore: release X" PR. Review the CHANGELOG diff per
+package, then merge. The same workflow re-runs on PR close (guarded by
+`if: startsWith(github.event.pull_request.head.ref, 'release-please--')`)
+and creates the per-package tags + GitHub Releases. Each Release event
+triggers `publish.yml` once, which publishes that one package.
+
+Watch progress:
+
+```sh
+gh run list --workflow=release-please.yml --repo mizchi/luna.mbt --limit 5
+gh run list --workflow=publish.yml       --repo mizchi/luna.mbt --limit 9
+```
+
+---
+
+## Day-to-day operation
+
+Once setup is done, the only manual step is **merging the Release PR**.
+Conventional Commits drive everything:
+
+- `feat(luna): ...` → bumps `@luna_ui/luna` minor
+- `fix(stella): ...` → bumps `@luna_ui/stella` patch
+- `feat(luna)!: ...` or `BREAKING CHANGE:` footer → major bump
+- Commits **without** a known scope are ignored — release-please can't
+  attribute them to a package and won't include them in the Release PR.
+
+Recognized scopes (from `release-please-config.json` package keys):
+`luna`, `sol`, `astra`, `components`, `loader` (publishes as `luna-loader`),
+`stella`, `testing`, `wcr`, `wcssr`.

--- a/js/astra/package.json
+++ b/js/astra/package.json
@@ -12,5 +12,13 @@
     "README.md"
   ],
   "description": "Astra — SSG / static-export companion for Sol (CLI wrapper)",
-  "repository": "https://github.com/mizchi/luna.mbt"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/astra"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/components/package.json
+++ b/js/components/package.json
@@ -78,5 +78,13 @@
     "aria",
     "apg"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/components"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/loader/package.json
+++ b/js/loader/package.json
@@ -50,5 +50,13 @@
     "web-components"
   ],
   "author": "mizchi",
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/loader"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/luna/package.json
+++ b/js/luna/package.json
@@ -72,9 +72,14 @@
     "tsdown": "0.21.0-beta.2"
   },
   "repository": {
-    "directory": "js/luna",
-    "url": "https://github.com/mizchi/luna.mbt"
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/luna"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
   "files": [
     "dist"
   ]

--- a/js/sol/package.json
+++ b/js/sol/package.json
@@ -12,5 +12,13 @@
     "README.md"
   ],
   "description": "Sol — SSR-first web framework for MoonBit (CLI wrapper)",
-  "repository": "https://github.com/mizchi/luna.mbt"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/sol"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/stella/package.json
+++ b/js/stella/package.json
@@ -34,5 +34,16 @@
     "luna",
     "moonbit"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/stella"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/testing/package.json
+++ b/js/testing/package.json
@@ -34,5 +34,13 @@
     "accessibility",
     "a11y"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/testing"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/wcr/package.json
+++ b/js/wcr/package.json
@@ -27,5 +27,16 @@
     "luna",
     "moonbit"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/wcr"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/js/wcssr/package.json
+++ b/js/wcssr/package.json
@@ -47,6 +47,14 @@
   ],
   "author": "mizchi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizchi/luna.mbt.git",
+    "directory": "js/wcssr"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",

--- a/luna/scripts/vup.mjs
+++ b/luna/scripts/vup.mjs
@@ -1,34 +1,35 @@
 #!/usr/bin/env node
 /**
- * Monorepo version bump for luna.mbt.
+ * Mooncakes-side version bump for luna.mbt.
  *
- * Bumps the three MoonBit packages and their npm wrappers in lockstep.
- * Each package owns its OWN version (luna / sol / astra are independent),
- * but a single semver bump (patch/minor/major) increments each one
- * relative to its current value.
+ * Bumps ONLY the three MoonBit packages (luna / sol / astra). Each package
+ * owns its own version, but a single semver bump (patch/minor/major)
+ * increments each one relative to its current value.
+ *
+ * The npm packages under js/* are NOT touched here — they are managed by
+ * release-please (see release-please-config.json + .github/workflows/release-please.yml).
  *
  * Files touched (always run from the repo root):
  *   luna/moon.mod.json
  *   sol/moon.mod.json   (also updates the inter-dep ref `mizchi/astra.{path,version}`
  *                        to match astra's new version)
  *   astra/moon.mod.json
- *   js/luna/package.json
- *   js/sol/package.json
- *   js/astra/package.json
  *
  * Usage:
  *   node luna/scripts/vup.mjs patch              # bump each 0.x.y -> 0.x.(y+1)
  *   node luna/scripts/vup.mjs minor              # bump each 0.x.y -> 0.(x+1).0
  *   node luna/scripts/vup.mjs major              # bump each 0.x.y -> (x+1).0.0
- *   node luna/scripts/vup.mjs 0.20.0             # set ALL packages to 0.20.0
+ *   node luna/scripts/vup.mjs 0.20.0             # set ALL mooncakes to 0.20.0
  *   node luna/scripts/vup.mjs --dry-run patch    # preview without writing
  *   node luna/scripts/vup.mjs patch --release    # write, commit, tag (per-package tags)
  *   node luna/scripts/vup.mjs patch --release --push   # release then push
  *
- * Tags created by --release reflect each package's actual new version:
+ * Tags created by --release are the mooncakes tags:
  *   luna-v<luna_version>
  *   sol-v<sol_version>
  *   astra-v<astra_version>
+ *
+ * release-please creates separate "@luna_ui/<pkg>-v<v>" tags for the npm side.
  *
  * See `just vup` for the wrapper that also regenerates per-package CHANGELOGs.
  */
@@ -48,13 +49,12 @@ const rootDir = join(__dirname, "..", "..");
 /**
  * Each package is identified by its short id (luna / sol / astra) and has:
  *   - moonModPath:   path to moon.mod.json
- *   - npmPath:       path to js/<id>/package.json
  *   - tagPrefix:     git tag prefix (e.g. "luna-v")
  */
 const PACKAGES = [
-  { id: "luna",  moonModPath: "luna/moon.mod.json",  npmPath: "js/luna/package.json",  tagPrefix: "luna-v"  },
-  { id: "sol",   moonModPath: "sol/moon.mod.json",   npmPath: "js/sol/package.json",   tagPrefix: "sol-v"   },
-  { id: "astra", moonModPath: "astra/moon.mod.json", npmPath: "js/astra/package.json", tagPrefix: "astra-v" },
+  { id: "luna",  moonModPath: "luna/moon.mod.json",  tagPrefix: "luna-v"  },
+  { id: "sol",   moonModPath: "sol/moon.mod.json",   tagPrefix: "sol-v"   },
+  { id: "astra", moonModPath: "astra/moon.mod.json", tagPrefix: "astra-v" },
 ];
 
 // =============================================================================
@@ -105,32 +105,23 @@ function writeJson(absPath, json, dryRun) {
 // =============================================================================
 
 /**
- * Build a plan: { id, currentMoon, newMoon, currentNpm, newNpm } per package.
- * For an explicit version, all six get that version.
- * For a semver bump, each is incremented relative to its OWN current version
- * (npm wrapper bumps relative to its own current value too — they currently
- * mirror but this keeps that loosely coupled).
+ * Build a plan: { id, currentMoon, newMoon } per package.
+ * For an explicit version, all entries get that version.
+ * For a semver bump, each is incremented relative to its OWN current version.
  */
 function buildPlan(spec) {
   return PACKAGES.map(pkg => {
     const moonAbs = join(rootDir, pkg.moonModPath);
-    const npmAbs = join(rootDir, pkg.npmPath);
     const moon = readJson(moonAbs);
-    const npm = readJson(npmAbs);
     const currentMoon = moon.version;
-    const currentNpm = npm.version;
     const newMoon = spec.kind === "explicit"
       ? spec.version
       : incrementVersion(currentMoon, spec.kind);
-    const newNpm = spec.kind === "explicit"
-      ? spec.version
-      : incrementVersion(currentNpm, spec.kind);
     return {
       ...pkg,
-      moonAbs, npmAbs,
-      moon, npm,
+      moonAbs,
+      moon,
       currentMoon, newMoon,
-      currentNpm, newNpm,
     };
   });
 }
@@ -160,10 +151,6 @@ function applyPlan(plan, dryRun) {
 
     writeJson(entry.moonAbs, entry.moon, dryRun);
     console.log(`  ${entry.moonModPath}: ${entry.currentMoon} -> ${entry.newMoon}`);
-
-    entry.npm.version = entry.newNpm;
-    writeJson(entry.npmAbs, entry.npm, dryRun);
-    console.log(`  ${entry.npmPath}: ${entry.currentNpm} -> ${entry.newNpm}`);
   }
 }
 
@@ -184,7 +171,7 @@ function release(plan, kind, dryRun, doPush) {
   console.log("\nReleasing...");
   exec("git add -A", dryRun);
   const kindLabel = kind === "explicit" ? "set version" : `bump ${kind}`;
-  exec(`git commit -m "chore: ${kindLabel} all packages"`, dryRun);
+  exec(`git commit -m "chore: ${kindLabel} all mooncakes packages"`, dryRun);
   for (const entry of plan) {
     exec(`git tag ${entry.tagPrefix}${entry.newMoon}`, dryRun);
   }
@@ -205,17 +192,21 @@ function printUsage() {
   node luna/scripts/vup.mjs patch|minor|major [--dry-run] [--release [--push]]
   node luna/scripts/vup.mjs <X.Y.Z>            [--dry-run] [--release [--push]]
 
-Touches all 6 manifests:
-  luna/moon.mod.json, sol/moon.mod.json, astra/moon.mod.json,
-  js/luna/package.json, js/sol/package.json, js/astra/package.json
+Scope:
+  This script bumps ONLY the 3 mooncakes packages (mizchi/{luna,sol,astra}).
+  The npm packages under js/* are managed by release-please — do not edit
+  their versions by hand. See docs/internal/npm-release-onboarding.md.
+
+Touches 3 manifests:
+  luna/moon.mod.json, sol/moon.mod.json, astra/moon.mod.json
   (sol/moon.mod.json deps.mizchi/astra.version is also bumped to match astra)
 
 Tags created by --release: luna-v<v>, sol-v<v>, astra-v<v>.
 
 Examples:
   node luna/scripts/vup.mjs --dry-run patch         # preview
-  node luna/scripts/vup.mjs patch                   # bump each package
-  node luna/scripts/vup.mjs 0.20.0                  # set all to 0.20.0
+  node luna/scripts/vup.mjs patch                   # bump each mooncakes package
+  node luna/scripts/vup.mjs 0.20.0                  # set all mooncakes to 0.20.0
   node luna/scripts/vup.mjs patch --release         # bump + commit + per-pkg tags
   node luna/scripts/vup.mjs patch --release --push  # ... and push
 `);

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "include-component-in-tag": true,
+  "separate-pull-requests": false,
+  "plugins": ["node-workspace"],
+  "packages": {
+    "js/luna":        { "package-name": "@luna_ui/luna" },
+    "js/sol":         { "package-name": "@luna_ui/sol" },
+    "js/astra":       { "package-name": "@luna_ui/astra" },
+    "js/components":  { "package-name": "@luna_ui/components" },
+    "js/loader":      { "package-name": "@luna_ui/luna-loader" },
+    "js/stella":      { "package-name": "@luna_ui/stella" },
+    "js/testing":     { "package-name": "@luna_ui/testing" },
+    "js/wcr":         { "package-name": "@luna_ui/wcr" },
+    "js/wcssr":       { "package-name": "@luna_ui/wcssr" }
+  }
+}


### PR DESCRIPTION
## Summary

- Set up release-please in manifest mode for the 9 publishable `@luna_ui/*` packages under `js/*` (luna, sol, astra, components, luna-loader, stella, testing, wcr, wcssr).
- Added `.github/workflows/publish.yml` that reacts to per-package GitHub Releases, resolves the tag back to its `js/<pkg>` directory, and runs `npm publish --provenance` under OIDC Trusted Publishing (no NPM_TOKEN).
- Added `repository.directory`, `publishConfig.access: public`, and missing `license: MIT` / `files` fields to all publishable `js/*/package.json` files.
- Re-scoped `luna/scripts/vup.mjs` to mooncakes-only (the npm side is now release-please's responsibility); documented the one-time maintainer setup in `docs/internal/npm-release-onboarding.md`.

## Verification

- `moon check --target js`: 0 errors (warnings unchanged from main)
- `moon test --target js`: 2794 PASS
- `pnpm test:integration`: 9/9 PASS
- `actionlint .github/workflows/*`: clean
- `node luna/scripts/vup.mjs --dry-run patch`: now previews only 3 files (luna/sol/astra moon.mod.json) — no js/* writes
- Both `release-please-config.json` and `.release-please-manifest.json` parse as valid JSON

## Maintainer action required before first publish

This PR adds the wiring; the workflows cannot publish until the
prerequisites in [`docs/internal/npm-release-onboarding.md`](./docs/internal/npm-release-onboarding.md) are done:

1. Create / install the `mizchi-release-please` GitHub App (app-id 3420845) on this repo and store the PEM as repo secret `RELEASE_PLEASE_APP_PRIVATE_KEY`.
2. Add a Trusted Publisher entry on npmjs.com for each of the 9 `@luna_ui/*` packages (workflow filename: `publish.yml`).
3. Manually `npm publish` any package that doesn't yet exist on npm to claim the name (likely `@luna_ui/sol`, `@luna_ui/astra`, possibly `@luna_ui/components` / `@luna_ui/testing`).
4. Set npm 2FA to "Authorization only" per package.
5. `gh workflow run release-please.yml` to create the first Release PR.

## Test plan

- [ ] After merging, complete the onboarding checklist
- [ ] Manually `gh workflow run release-please.yml` and verify a chore PR is opened
- [ ] Merge the Release PR and confirm `publish.yml` runs once per package, with provenance attestations visible on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)