### PR TITLE
chore(release-please): wcssr private + astra manifest 0.3.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,10 @@
 {
   "js/luna": "0.16.3",
   "js/sol": "0.16.2",
-  "js/astra": "0.1.2",
+  "js/astra": "0.3.0",
   "js/components": "0.1.0",
   "js/loader": "0.3.1",
   "js/stella": "0.3.1",
   "js/testing": "0.1.0",
-  "js/wcr": "0.3.1",
-  "js/wcssr": "0.3.1"
+  "js/wcr": "0.3.1"
 }

--- a/docs/internal/npm-release-onboarding.md
+++ b/docs/internal/npm-release-onboarding.md
@@ -13,7 +13,9 @@ The two workflows together handle:
   the matching `js/<pkg>` directory using OIDC Trusted Publishing
   (no NPM_TOKEN needed).
 
-Scope: 9 packages — `@luna_ui/{luna,sol,astra,components,luna-loader,stella,testing,wcr,wcssr}`.
+Scope: 8 packages — `@luna_ui/{luna,sol,astra,components,luna-loader,stella,testing,wcr}`.
+
+(`@luna_ui/wcssr` is `private: true` and excluded from release-please. Re-enable by removing `"private": true` from `js/wcssr/package.json` and adding `"js/wcssr"` back to `release-please-config.json` + `.release-please-manifest.json`.)
 
 The 3 mooncakes packages (`mizchi/{luna,sol,astra}` MoonBit modules) stay
 on the existing `luna/scripts/vup.mjs` flow and are out of scope here.
@@ -46,12 +48,12 @@ create and approve pull requests" repo-wide.
 
 ---
 
-## 2. npm Trusted Publisher registration (per package, 9×)
+## 2. npm Trusted Publisher registration (per package, 8×)
 
 OIDC Trusted Publishing replaces NPM_TOKEN. Each package must be told
 which GitHub workflow is allowed to publish it.
 
-For **each** of the 9 packages below:
+For **each** of the 8 packages below:
 
 1. Sign in at <https://www.npmjs.com>.
 2. Go to the package page → **Settings** → **Trusted Publisher** → **Add**.
@@ -72,7 +74,6 @@ Packages:
 - `@luna_ui/stella`
 - `@luna_ui/testing`
 - `@luna_ui/wcr`
-- `@luna_ui/wcssr`
 
 ---
 
@@ -86,7 +87,7 @@ over for subsequent releases.
 Check current state:
 
 ```sh
-for pkg in luna sol astra components luna-loader stella testing wcr wcssr; do
+for pkg in luna sol astra components luna-loader stella testing wcr; do
   printf '%s: ' "@luna_ui/${pkg}"
   npm view "@luna_ui/${pkg}" version 2>/dev/null || echo '(not published)'
 done
@@ -159,4 +160,4 @@ Conventional Commits drive everything:
 
 Recognized scopes (from `release-please-config.json` package keys):
 `luna`, `sol`, `astra`, `components`, `loader` (publishes as `luna-loader`),
-`stella`, `testing`, `wcr`, `wcssr`.
+`stella`, `testing`, `wcr`.

--- a/js/astra/package.json
+++ b/js/astra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/astra",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "bin": {

--- a/js/wcssr/package.json
+++ b/js/wcssr/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@luna_ui/wcssr",
   "version": "0.3.1",
+  "private": true,
   "description": "Web Components SSR runtime with functional API",
   "type": "module",
   "main": "./dist/index.js",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,6 @@
     "js/loader":      { "package-name": "@luna_ui/luna-loader" },
     "js/stella":      { "package-name": "@luna_ui/stella" },
     "js/testing":     { "package-name": "@luna_ui/testing" },
-    "js/wcr":         { "package-name": "@luna_ui/wcr" },
-    "js/wcssr":       { "package-name": "@luna_ui/wcssr" }
+    "js/wcr":         { "package-name": "@luna_ui/wcr" }
   }
 }


### PR DESCRIPTION
Two corrections after PR #37:

1. **@luna_ui/wcssr** — set `private: true`. No internal consumers, and not intended for publication. Removed from release-please config + manifest. Re-enable later by reverting both files.

2. **@luna_ui/astra** — npm already has 0.3.0; our 0.1.2 conflicts on publish. Bump js/astra/package.json + manifest to 0.3.0 so next patch lands at 0.3.1.

Onboarding doc updated: 9→8 packages.