### PR TITLE
chore(release-please): align all 8 npm packages at 0.17.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,17 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "bootstrap-sha": "02c638d2ac8be3487ab3cad3399db4468473bdc0",
   "include-component-in-tag": true,
   "separate-pull-requests": false,
   "plugins": ["node-workspace"],
   "packages": {
-    "js/luna":        { "package-name": "@luna_ui/luna" },
-    "js/sol":         { "package-name": "@luna_ui/sol" },
-    "js/astra":       { "package-name": "@luna_ui/astra" },
-    "js/components":  { "package-name": "@luna_ui/components" },
-    "js/loader":      { "package-name": "@luna_ui/luna-loader" },
-    "js/stella":      { "package-name": "@luna_ui/stella" },
-    "js/testing":     { "package-name": "@luna_ui/testing" },
-    "js/wcr":         { "package-name": "@luna_ui/wcr" }
+    "js/luna":        { "package-name": "@luna_ui/luna",       "release-as": "0.17.0" },
+    "js/sol":         { "package-name": "@luna_ui/sol",        "release-as": "0.17.0" },
+    "js/astra":       { "package-name": "@luna_ui/astra",      "release-as": "0.17.0" },
+    "js/components":  { "package-name": "@luna_ui/components", "release-as": "0.17.0" },
+    "js/loader":      { "package-name": "@luna_ui/luna-loader","release-as": "0.17.0" },
+    "js/stella":      { "package-name": "@luna_ui/stella",     "release-as": "0.17.0" },
+    "js/testing":     { "package-name": "@luna_ui/testing",    "release-as": "0.17.0" },
+    "js/wcr":         { "package-name": "@luna_ui/wcr",        "release-as": "0.17.0" }
   }
 }


### PR DESCRIPTION
Reset after PR #39 (closed) which collected too much history.

- `bootstrap-sha = 02c638d2` (current main HEAD) — release-please ignores anything before this
- `release-as: "0.17.0"` per package — next dispatch creates a single Release PR aligning all 8 packages to 0.17.0 baseline
- After merge, the publish workflow runs `npm publish` × 8 (provenance via OIDC)
- Future releases bump each package independently from 0.17.x