### PR TITLE
chore(release-please): drop bootstrap-sha for 0.17.0 alignment

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "bootstrap-sha": "02c638d2ac8be3487ab3cad3399db4468473bdc0",
   "include-component-in-tag": true,
   "separate-pull-requests": false,
   "plugins": ["node-workspace"],


### PR DESCRIPTION
Reset attempt 2 after PR #40.

bootstrap-sha at HEAD made release-please skip everything (0 commits visible). Drop it so the action scans full history; `release-as: 0.17.0` still pins every package to 0.17.0 regardless of BREAKING flags.