### PR TITLE
chore(sol): align @luna_ui/sol to 0.17.0 after manual publish

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "js/luna": "0.17.0",
-  "js/sol": "0.16.2",
+  "js/sol": "0.17.0",
   "js/astra": "0.17.0",
   "js/components": "0.17.0",
   "js/loader": "0.17.0",

--- a/js/sol/package.json
+++ b/js/sol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/sol",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "private": false,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bumps `js/sol/package.json` 0.16.2 → 0.17.0 to match the version manually published to npm.
- Updates `.release-please-manifest.json` so the next release-please run sees 0.17.0 as the baseline.

## Why manual publish

`@luna_ui/sol` was skipped by release-please because its manifest entry `0.16.2` collided with the existing mooncakes-side tag `sol-v0.16.2` (mooncakes' `vup.mjs` flow uses the same `<component>-v<version>` tag namespace as release-please's default `include-component-in-tag` output). release-please saw `sol-v0.16.2` as already-released and produced no Release PR for sol.

Published 0.17.0 manually from local with `npm publish --access public` (no provenance — local environment can't generate it).

## Follow-up (not in this PR)

To prevent the collision recurring, eventually move release-please's tag namespace to `@luna_ui/<pkg>-v<version>` by setting an explicit `component` per package in `release-please-config.json`. Skipped here to avoid disturbing the 7 already-tagged packages.

## Test plan

- [ ] `npm view @luna_ui/sol version` returns `0.17.0`
- [ ] All 8 `@luna_ui/*` packages show `0.17.0` on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)