### PR TITLE
ci(website): deploy docs to luna.mizchi.workers.dev

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,59 @@
+name: deploy-website
+
+# Builds the docs site under website/ with `astra build` (SSG mode) and
+# deploys the resulting dist-docs/ to luna.mizchi.workers.dev as a
+# Cloudflare Workers Static Assets worker (no SSR runtime; pure CDN).
+#
+# Trigger: tied to release-please's @luna_ui/luna release event. When the
+# Release PR merges, release-please publishes 8 GitHub Releases roughly
+# in parallel; we listen only to the luna-v* tag so the website is
+# deployed once per release cycle (not 8 times).
+#
+# workflow_dispatch is the manual fallback for redeploying off-cycle.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'luna-v') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+
+      - run: moon update
+
+      - run: pnpm install --frozen-lockfile
+
+      # astra binary lives at _build/js/release/build/mizchi/astra/cmd/astra/astra.js,
+      # produced by `moon build --target js --release`. Workspace-wide build
+      # also handles luna's tsdown step which reads moonbit-built api.js files.
+      - run: moon build --target js --release
+
+      - run: pnpm -r build
+
+      - name: astra build (SSG)
+        working-directory: website
+        run: node ../js/astra/bin/astra.js build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: website
+          wranglerVersion: "4"

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@
 target/
 dist/
 !js/loader/dist/
+dist-docs/
 _build/
+
+# Wrangler / Cloudflare Workers
+.wrangler/
 node_modules/
 .mooncakes/
 

--- a/website/wrangler.json
+++ b/website/wrangler.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "luna",
+  "compatibility_date": "2025-10-01",
+  "assets": {
+    "directory": "./dist-docs",
+    "not_found_handling": "404-page"
+  },
+  "observability": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-website.yml` — builds `website/` with `astra build` (SSG mode → `dist-docs/`) and deploys to Cloudflare Workers Static Assets as worker `luna`.
- Adds `website/wrangler.json` (Workers Static Assets config, no `main`, just `assets.directory`).
- Adds `dist-docs/` and `.wrangler/` to `.gitignore`.

## Trigger design

Tied to `@luna_ui/luna` GitHub Release event (`luna-v*` tag). When a release-please cycle merges, 8 Releases fire roughly in parallel — listening only on `luna-v*` deploys the website exactly once per cycle. `workflow_dispatch` is wired up for manual redeploy.

## Prerequisites (maintainer action required before merge or first deploy)

- [ ] Create Cloudflare API token (scope: Workers Scripts:Edit on the mizchi account)
- [ ] `gh secret set CLOUDFLARE_API_TOKEN --repo mizchi/luna.mbt --body '<token>'`
- [ ] Confirm worker name `luna` is available on the mizchi Cloudflare account (claimed by the first deploy)

## Test plan

- [ ] After merge + secret registration: `gh workflow run deploy-website.yml --repo mizchi/luna.mbt` and confirm the deploy succeeds
- [ ] Visit https://luna.mizchi.workers.dev/ and verify the index page renders
- [ ] On the next release-please merge, confirm `deploy-website` is fired by the `luna-v*` Release event (not the other 7)

## Verified locally

- \`astra build\` from \`website/\` outputs 139 URLs / 274 files / 8.4MB to \`dist-docs/\`
- \`pnpm dlx wrangler@4 deploy --dry-run\` validates the wrangler.json config

🤖 Generated with [Claude Code](https://claude.com/claude-code)