### PR TITLE
fix(website): add package.json so wrangler-action can install wrangler

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@luna_ui/website",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Luna UI documentation site (built by astra, deployed to Cloudflare Workers as the `luna` worker)."
+}


### PR DESCRIPTION
## Summary

Adds a minimal \`website/package.json\` so \`cloudflare/wrangler-action@v3\` can run \`npm i wrangler@4\` in \`workingDirectory: website\`.

## Root cause

The first \`deploy-website\` run (25426317248) failed at the Deploy step with:

\`\`\`
[command]/opt/hostedtoolcache/node/24.14.1/x64/bin/npm i wrangler@4
npm error Cannot read properties of null (reading 'name')
\`\`\`

\`wrangler-action\` shells out to npm without checking that \`workingDirectory\` actually has a package.json. With none present, npm 11 crashes early.

## Fix

A private, version-0.0.0 package.json is enough — wrangler installs into \`website/node_modules/\` per-job and is discarded with the runner. Nothing needs to register the website as a pnpm workspace member.

## Test plan

- [ ] After merge: \`gh workflow run deploy-website.yml --repo mizchi/luna.mbt\`
- [ ] \"Deploy to Cloudflare Workers\" step succeeds
- [ ] https://luna.mizchi.workers.dev/ serves the index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)