### PR TITLE
fix(website): pass accountId so wrangler skips /memberships lookup

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -55,5 +55,10 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # accountId is set explicitly so wrangler skips the /memberships
+          # auto-detect call. Without it, an API token that lacks
+          # User > Memberships:Read fails with 9106 even though the token
+          # has the right Workers Scripts:Edit scope for the actual deploy.
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: website
           wranglerVersion: "4"


### PR DESCRIPTION
## Summary

Adds \`accountId: \${{ secrets.CLOUDFLARE_ACCOUNT_ID }}\` to \`deploy-website.yml\` so wrangler doesn't fall back to the \`/memberships\` API for account auto-detection.

## Root cause

Two consecutive runs (25426572471, 25427301470) failed at \`wrangler deploy\` with:

\`\`\`
A request to the Cloudflare API (/memberships) failed.
Authentication failed (status: 400) [code: 9106]
\`\`\`

The token has Workers Scripts:Edit (sufficient for the actual deploy) but lacks User > Memberships:Read, which wrangler needs only when guessing the account. Passing accountId explicitly is a stricter, narrower-scope alternative to broadening the token.

## Test plan

- [ ] After merge: \`gh workflow run deploy-website.yml --repo mizchi/luna.mbt\`
- [ ] Deploy step succeeds, https://luna.mizchi.workers.dev/ serves the index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)