### PR TITLE
fix(astra-shim): set __sol_assets_dir so docs builds find main.css

### DIFF
--- a/js/astra/bin/astra.js
+++ b/js/astra/bin/astra.js
@@ -6,4 +6,25 @@
 // npm wrapper exists for users who already have node but not moon.
 // Published npm builds bundle the moonbit CLI output into ./dist/ via
 // js/astra/scripts/build-release.mjs (TODO).
-import "../../../_build/js/release/build/mizchi/astra/cmd/astra/astra.js";
+//
+// Asset resolution: astra's load_asset() tries a fixed list of cwd-relative
+// paths to find styles/main.css etc. When astra build is invoked from a
+// docs directory like website/, none of those candidates resolves to the
+// astra source tree at <repo>/astra/src/assets. Without this override,
+// load_asset falls through to its tiny inline fallback CSS and the docs
+// site loses ~2900 lines of component CSS. Setting __sol_assets_dir on
+// globalThis short-circuits the search to the right directory whenever
+// the shim is being run from inside the luna.mbt monorepo. The dynamic
+// import below ensures this assignment runs before astra's MoonBit JS
+// reads load_asset's first candidate.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const workspaceAssets = path.resolve(__dirname, "../../../astra/src/assets");
+if (existsSync(workspaceAssets)) {
+  globalThis.__sol_assets_dir = workspaceAssets;
+}
+
+await import("../../../_build/js/release/build/mizchi/astra/cmd/astra/astra.js");

--- a/tests/integration/website-css-bundling.test.js
+++ b/tests/integration/website-css-bundling.test.js
@@ -1,0 +1,54 @@
+// Regression test for the bug fixed in PR #47:
+// `astra build` invoked from website/ produced a 143-byte fallback
+// style.css instead of inlining astra/src/assets/styles/main.css
+// (~47KB), because load_asset() in astra has no cwd-relative path that
+// reaches <repo>/astra/src/assets when run from a docs directory. The
+// fix in js/astra/bin/astra.js sets globalThis.__sol_assets_dir to
+// short-circuit load_asset's lookup. If that override regresses, this
+// test catches it before the website ships with broken styling.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, statSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..", "..");
+const ASTRA_SHIM = path.join(ROOT, "js", "astra", "bin", "astra.js");
+const WEBSITE_DIR = path.join(ROOT, "website");
+
+test("astra build from website/ inlines full main.css", () => {
+  const outDir = mkdtempSync(path.join(tmpdir(), "astra-css-regression-"));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [ASTRA_SHIM, "build", "--out", outDir],
+      { cwd: WEBSITE_DIR, encoding: "utf-8" },
+    );
+    assert.equal(
+      result.status,
+      0,
+      `astra build failed:\nstdout=${result.stdout}\nstderr=${result.stderr}`,
+    );
+
+    const stylePath = path.join(outDir, "assets", "style.css");
+    const styleSize = statSync(stylePath).size;
+
+    // Full minified main.css is ~47KB; the get_fallback_css() path
+    // emits ~143 bytes. A 10KB threshold stays comfortably above the
+    // fallback and below the live size, so theme refactors that trim
+    // a few hundred bytes don't false-positive this test.
+    assert.ok(
+      styleSize > 10_000,
+      `${stylePath} is ${styleSize} bytes — too small to contain ` +
+        `astra/src/assets/styles/main.css. The shim probably failed to ` +
+        `set globalThis.__sol_assets_dir, or load_asset's lookup ` +
+        `chain regressed.`,
+    );
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Updates the workspace dev shim at \`js/astra/bin/astra.js\` to set \`globalThis.__sol_assets_dir\` to \`<repo>/astra/src/assets\` before astra's MoonBit JS loads. This is the highest-priority candidate in \`load_asset()\`, so it short-circuits the cwd-relative search.

## Root cause

\`astra/src/assets/loader.mbt::load_asset()\` tries a fixed list of cwd-relative paths to find \`styles/main.css\`. Running \`astra build\` from \`website/\` (cwd = \`website\`) gives no candidate that resolves to \`<repo>/astra/src/assets/\` — none of the relative paths walks back up out of \`website/\`. \`get_default_css()\` falls back silently to an inline mini-CSS via \`get_fallback_css()\`, dropping ~2900 lines of component CSS.

That's exactly what produced the deployed \`luna.mizchi.workers.dev\` rendering with no layout/nav/hero styles. Locally:

\`\`\`
# before
dist-docs/assets/style.css: 143 bytes (fallback only)

# after
dist-docs/assets/style.css: 47516 bytes (full main.css)
\`\`\`

## Why on the shim

\`load_asset()\` already supports a \`__sol_assets_dir\` global as its first candidate, intended for exactly this kind of JS-side override. The shim is the right place to set it because:

1. The shim already knows it's running from \`<repo>/js/astra/bin/\` — it can compute the source path with no config.
2. A presence check (\`existsSync\`) guards the override so npm-installed users (where the shim ships but the astra source doesn't) get the original \`load_asset()\` fallback chain.

## Test plan

- [x] \`cd website && rm -rf dist-docs && node ../js/astra/bin/astra.js build\` produces a 47KB style.css and an inline \`<style>\` block matching main.css
- [ ] After merge: \`gh workflow run deploy-website.yml\` and confirm https://luna.mizchi.workers.dev/ renders with full component styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)