### PR TITLE
docs(readme): refresh versions, documentation URLs, release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,16 @@ published independently to [mooncakes](https://mooncakes.io/):
 
 | Package | Role | Path | Latest |
 |---------|------|------|--------|
-| [`mizchi/luna`](./luna/)    | UI primitive — VDOM, hydration, stream renderer, Island runtime | `luna/`  | 0.19.2 |
+| [`mizchi/luna`](./luna/)    | UI primitive — VDOM, hydration, stream renderer, Island runtime | `luna/`  | 0.19.3 |
 | [`mizchi/sol`](./sol/)      | Mars-based SSR framework with file-based routing                | `sol/`   | 0.16.2 |
 | [`mizchi/astra`](./astra/)  | Mountable Mars middleware for static site generation            | `astra/` | 0.1.2  |
 
 Each package's README has the canonical usage doc.
+
+## Documentation
+
+- https://luna.mizchi.workers.dev/ (Cloudflare Workers, canonical)
+- https://mizchi.github.io/luna.mbt/ (GitHub Pages, mirror — accessible from regions where `workers.dev` is blocked)
 
 ## Install — library
 
@@ -17,13 +22,13 @@ Add to your `moon.mod.json`:
 
 ```jsonc
 // UI library only
-{ "deps": { "mizchi/luna": "0.19.2" } }
+{ "deps": { "mizchi/luna": "0.19.3" } }
 
 // SSR framework
-{ "deps": { "mizchi/sol": "0.16.2", "mizchi/luna": "0.19.2" } }
+{ "deps": { "mizchi/sol": "0.16.2", "mizchi/luna": "0.19.3" } }
 
 // Static-site middleware (mounts on a Mars Server)
-{ "deps": { "mizchi/astra": "0.1.2", "mizchi/luna": "0.19.2" } }
+{ "deps": { "mizchi/astra": "0.1.2", "mizchi/luna": "0.19.3" } }
 ```
 
 ## Install — CLI
@@ -35,11 +40,20 @@ moon install mizchi/sol/cmd/sol      # → $MOON_HOME/bin/sol
 moon install mizchi/astra/cmd/astra  # → $MOON_HOME/bin/astra
 ```
 
-An npm wrapper exists for users who already have node but not moon:
+npm wrappers exist for users who already have node but not moon. The full
+[`@luna_ui/*`](https://www.npmjs.com/org/luna_ui) family is published in
+lockstep at the same minor version, currently `0.17.0`:
 
 ```sh
-pnpm add -g @luna_ui/sol     # 0.16.2
-pnpm add -g @luna_ui/astra   # 0.1.2
+pnpm add -g @luna_ui/sol      # SSR framework CLI
+pnpm add -g @luna_ui/astra    # SSG CLI
+
+pnpm add @luna_ui/luna           # core UI library
+pnpm add @luna_ui/components     # built-in components
+pnpm add @luna_ui/luna-loader    # loader runtime
+pnpm add @luna_ui/stella         # Suspense / streaming helpers
+pnpm add @luna_ui/wcr            # web-component reactive bindings
+pnpm add @luna_ui/testing        # test helpers
 ```
 
 ## Layout
@@ -61,6 +75,26 @@ just test-unit      # MoonBit tests (luna + sol + astra)
 just test-e2e       # Playwright e2e (luna + sol + astra)
 pnpm test:integration   # build/dev parity + 7-example matrix (node:test)
 ```
+
+## Release pipeline
+
+- mooncakes (`mizchi/{luna,sol,astra}`) is bumped via `luna/scripts/vup.mjs`
+  and pushed to https://mooncakes.io/.
+- npm (`@luna_ui/*`) is automated end-to-end:
+  - `release-please` (workflow_dispatch) opens a Release PR aggregating
+    Conventional Commits across `js/*`.
+  - Merging the PR creates per-package GitHub Releases tagged
+    `<pkg>-v<version>`.
+  - `.github/workflows/publish.yml` reacts to each Release event and runs
+    `npm publish --provenance` from the matching `js/<pkg>` directory using
+    OIDC Trusted Publishing (no `NPM_TOKEN`).
+- Documentation deploys (`luna.mizchi.workers.dev`,
+  `mizchi.github.io/luna.mbt`) are tied to the `@luna_ui/luna` Release event,
+  so each release-please cycle redeploys the docs once for both targets.
+
+See `docs/internal/npm-release-onboarding.md` for the maintainer setup
+(GitHub App secret, npm Trusted Publisher × 8 packages, Cloudflare API
+token + account ID, GH Pages source).
 
 ## Background
 


### PR DESCRIPTION
## Summary

- **Versions**: bump shown \`mizchi/luna\` 0.19.2 → 0.19.3 (current mooncakes head).
- **npm packages**: replace per-package version comments with a note that all \`@luna_ui/*\` packages release in lockstep at \`0.17.0\`; list the seven publicly-published packages.
- **Documentation section** (new): links the two docs targets:
  - https://luna.mizchi.workers.dev/ (canonical, Cloudflare Workers)
  - https://mizchi.github.io/luna.mbt/ (mirror, GitHub Pages — China-accessible)
- **Release pipeline section** (new): summarizes the \`release-please\` → \`publish.yml\` → \`deploy-website\` / \`deploy-pages\` chain. Points at \`docs/internal/npm-release-onboarding.md\` for one-time setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)