### PR TITLE
fix(npm): bundle sol/astra CLI into dist/ for npm distribution

### DIFF
--- a/js/astra/bin/astra.js
+++ b/js/astra/bin/astra.js
@@ -1,30 +1,58 @@
 #!/usr/bin/env node
-// Workspace dev shim. js/astra/bin/astra.js -> three levels up to
-// workspace root, then into _build/js/release/build/mizchi/astra/cmd/astra/astra.js.
+// Entry point for the @luna_ui/astra npm wrapper.
 //
 // Primary install path is `moon install mizchi/astra/cmd/astra`; this
 // npm wrapper exists for users who already have node but not moon.
-// Published npm builds bundle the moonbit CLI output into ./dist/ via
-// js/astra/scripts/build-release.mjs (TODO).
 //
-// Asset resolution: astra's load_asset() tries a fixed list of cwd-relative
-// paths to find styles/main.css etc. When astra build is invoked from a
-// docs directory like website/, none of those candidates resolves to the
-// astra source tree at <repo>/astra/src/assets. Without this override,
-// load_asset falls through to its tiny inline fallback CSS and the docs
-// site loses ~2900 lines of component CSS. Setting __sol_assets_dir on
-// globalThis short-circuits the search to the right directory whenever
-// the shim is being run from inside the luna.mbt monorepo. The dynamic
-// import below ensures this assignment runs before astra's MoonBit JS
-// reads load_asset's first candidate.
+// CLI resolution order:
+//   1. ../dist/astra.js — populated by scripts/build-release.mjs at
+//      publish time. This is the path used in real npm installs.
+//   2. ../../../_build/js/release/build/mizchi/astra/cmd/astra/astra.js
+//      — workspace fallback so the shim stays usable from a clean
+//      monorepo checkout, which is what tests/integration/* relies on.
+//
+// Asset resolution: astra's load_asset() tries a fixed list of
+// cwd-relative paths to find styles/main.css etc. None of those resolve
+// when the CLI is installed via npm, so we set globalThis.__sol_assets_dir
+// to short-circuit the lookup. Bundled assets in dist/assets/ take
+// precedence; the workspace path is the dev fallback.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distEntry = path.resolve(__dirname, "../dist/astra.js");
+const workspaceEntry = path.resolve(
+  __dirname,
+  "../../../_build/js/release/build/mizchi/astra/cmd/astra/astra.js",
+);
+const distAssets = path.resolve(__dirname, "../dist/assets");
 const workspaceAssets = path.resolve(__dirname, "../../../astra/src/assets");
-if (existsSync(workspaceAssets)) {
-  globalThis.__sol_assets_dir = workspaceAssets;
+
+const entry = existsSync(distEntry)
+  ? distEntry
+  : existsSync(workspaceEntry)
+    ? workspaceEntry
+    : null;
+
+if (!entry) {
+  console.error(
+    "astra CLI binary not found. Tried:\n" +
+      `  ${distEntry}\n` +
+      `  ${workspaceEntry}\n` +
+      "If running from the luna.mbt monorepo, run " +
+      "`moon build --target js --release` first.",
+  );
+  process.exit(1);
 }
 
-await import("../../../_build/js/release/build/mizchi/astra/cmd/astra/astra.js");
+const assetsDir = existsSync(distAssets)
+  ? distAssets
+  : existsSync(workspaceAssets)
+    ? workspaceAssets
+    : null;
+if (assetsDir) {
+  globalThis.__sol_assets_dir = assetsDir;
+}
+
+await import(entry);

--- a/js/astra/package.json
+++ b/js/astra/package.json
@@ -9,8 +9,16 @@
   "main": "./bin/astra.js",
   "files": [
     "bin/",
+    "dist/",
     "README.md"
   ],
+  "scripts": {
+    "build": "node scripts/build-release.mjs",
+    "prepack": "node scripts/build-release.mjs"
+  },
+  "dependencies": {
+    "colorette": "^2.0.20"
+  },
   "description": "Astra — SSG / static-export companion for Sol (CLI wrapper)",
   "license": "MIT",
   "repository": {

--- a/js/astra/scripts/build-release.mjs
+++ b/js/astra/scripts/build-release.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Bundles the moonbit-built astra CLI plus its runtime asset directory
+// into js/astra/dist/. astra's load_asset() has no cwd-relative path
+// that resolves to assets when the CLI is installed via npm, so the
+// bin shim points globalThis.__sol_assets_dir at the bundled copy.
+// Only runtime-loaded subdirs (styles/, scripts/) are copied — the
+// .mbt source files in astra/src/assets/ are already compiled into
+// astra.js.
+import { copyFileSync, cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = path.resolve(__dirname, "..");
+const ROOT = path.resolve(__dirname, "../../..");
+const SRC_JS = path.join(
+  ROOT,
+  "_build/js/release/build/mizchi/astra/cmd/astra/astra.js",
+);
+const SRC_ASSETS = path.join(ROOT, "astra/src/assets");
+const OUT_DIR = path.join(PKG_DIR, "dist");
+
+for (const p of [SRC_JS, SRC_ASSETS]) {
+  if (!existsSync(p)) {
+    console.error(
+      `Missing ${p}\n` +
+        "Run `moon build --target js --release` from the workspace root first.",
+    );
+    process.exit(1);
+  }
+}
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+copyFileSync(SRC_JS, path.join(OUT_DIR, "astra.js"));
+
+for (const sub of ["styles", "scripts"]) {
+  const from = path.join(SRC_ASSETS, sub);
+  if (existsSync(from)) {
+    cpSync(from, path.join(OUT_DIR, "assets", sub), { recursive: true });
+  }
+}
+
+console.log(`Wrote ${path.relative(ROOT, OUT_DIR)}/`);

--- a/js/sol/bin/sol.js
+++ b/js/sol/bin/sol.js
@@ -1,9 +1,42 @@
 #!/usr/bin/env node
-// Workspace dev shim. js/sol/bin/sol.js -> three levels up to workspace
-// root, then into _build/js/release/build/mizchi/sol/cmd/sol/sol.js.
+// Entry point for the @luna_ui/sol npm wrapper.
 //
-// Primary install path is `moon install mizchi/sol/cmd/sol`; this
-// npm wrapper exists for users who already have node but not moon.
-// Published npm builds bundle the moonbit CLI output into ./dist/ via
-// js/sol/scripts/build-release.mjs (TODO).
-import "../../../_build/js/release/build/mizchi/sol/cmd/sol/sol.js";
+// Primary install path is `moon install mizchi/sol/cmd/sol`; this npm
+// wrapper exists for users who already have node but not moon.
+//
+// Resolution order:
+//   1. ../dist/sol.js — populated by scripts/build-release.mjs at
+//      publish time. This is the path used in real npm installs.
+//   2. ../../../_build/js/release/build/mizchi/sol/cmd/sol/sol.js —
+//      workspace fallback so the shim stays usable from a clean
+//      monorepo checkout (after `moon build --target js --release`),
+//      which is what tests/integration/* relies on.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distEntry = path.resolve(__dirname, "../dist/sol.js");
+const workspaceEntry = path.resolve(
+  __dirname,
+  "../../../_build/js/release/build/mizchi/sol/cmd/sol/sol.js",
+);
+
+const entry = existsSync(distEntry)
+  ? distEntry
+  : existsSync(workspaceEntry)
+    ? workspaceEntry
+    : null;
+
+if (!entry) {
+  console.error(
+    "sol CLI binary not found. Tried:\n" +
+      `  ${distEntry}\n` +
+      `  ${workspaceEntry}\n` +
+      "If running from the luna.mbt monorepo, run " +
+      "`moon build --target js --release` first.",
+  );
+  process.exit(1);
+}
+
+await import(entry);

--- a/js/sol/package.json
+++ b/js/sol/package.json
@@ -9,8 +9,16 @@
   "main": "./bin/sol.js",
   "files": [
     "bin/",
+    "dist/",
     "README.md"
   ],
+  "scripts": {
+    "build": "node scripts/build-release.mjs",
+    "prepack": "node scripts/build-release.mjs"
+  },
+  "dependencies": {
+    "colorette": "^2.0.20"
+  },
   "description": "Sol — SSR-first web framework for MoonBit (CLI wrapper)",
   "license": "MIT",
   "repository": {

--- a/js/sol/scripts/build-release.mjs
+++ b/js/sol/scripts/build-release.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Bundles the moonbit-built sol CLI into js/sol/dist/ so npm installs
+// resolve a self-contained file rather than the workspace _build/ tree.
+// Invoked from the package's `build` script — `pnpm -r build` in CI
+// runs this automatically before `npm publish`.
+import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = path.resolve(__dirname, "..");
+const ROOT = path.resolve(__dirname, "../../..");
+const SRC = path.join(
+  ROOT,
+  "_build/js/release/build/mizchi/sol/cmd/sol/sol.js",
+);
+const OUT_DIR = path.join(PKG_DIR, "dist");
+const OUT = path.join(OUT_DIR, "sol.js");
+
+if (!existsSync(SRC)) {
+  console.error(
+    `Missing ${SRC}\n` +
+      "Run `moon build --target js --release` from the workspace root first.",
+  );
+  process.exit(1);
+}
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+copyFileSync(SRC, OUT);
+console.log(`Wrote ${path.relative(ROOT, OUT)}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,11 @@ importers:
         specifier: ^4.57.1
         version: 4.57.2(tslib@2.8.1)
 
-  js/astra: {}
+  js/astra:
+    dependencies:
+      colorette:
+        specifier: ^2.0.20
+        version: 2.0.20
 
   js/components:
     devDependencies:
@@ -158,7 +162,11 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.2)(tsx@4.21.0)
 
-  js/sol: {}
+  js/sol:
+    dependencies:
+      colorette:
+        specifier: ^2.0.20
+        version: 2.0.20
 
   js/stella:
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,13 +5,13 @@
   "separate-pull-requests": false,
   "plugins": ["node-workspace"],
   "packages": {
-    "js/luna":        { "package-name": "@luna_ui/luna",       "release-as": "0.17.0" },
-    "js/sol":         { "package-name": "@luna_ui/sol",        "release-as": "0.17.0" },
-    "js/astra":       { "package-name": "@luna_ui/astra",      "release-as": "0.17.0" },
-    "js/components":  { "package-name": "@luna_ui/components", "release-as": "0.17.0" },
-    "js/loader":      { "package-name": "@luna_ui/luna-loader","release-as": "0.17.0" },
-    "js/stella":      { "package-name": "@luna_ui/stella",     "release-as": "0.17.0" },
-    "js/testing":     { "package-name": "@luna_ui/testing",    "release-as": "0.17.0" },
-    "js/wcr":         { "package-name": "@luna_ui/wcr",        "release-as": "0.17.0" }
+    "js/luna":        { "package-name": "@luna_ui/luna" },
+    "js/sol":         { "package-name": "@luna_ui/sol" },
+    "js/astra":       { "package-name": "@luna_ui/astra" },
+    "js/components":  { "package-name": "@luna_ui/components" },
+    "js/loader":      { "package-name": "@luna_ui/luna-loader" },
+    "js/stella":      { "package-name": "@luna_ui/stella" },
+    "js/testing":     { "package-name": "@luna_ui/testing" },
+    "js/wcr":         { "package-name": "@luna_ui/wcr" }
   }
 }

--- a/tests/integration/npm-cli-pack.test.js
+++ b/tests/integration/npm-cli-pack.test.js
@@ -1,0 +1,173 @@
+// Regression coverage for `pnpm add -g @luna_ui/sol` / `@luna_ui/astra`.
+// Up to 0.17.0 the bin shim imported `../../../_build/...` directly,
+// which only resolves inside the workspace — every npm install crashed
+// with ERR_MODULE_NOT_FOUND. The fix is to bundle the moonbit CLI JS
+// (and astra's runtime asset directory) into js/<pkg>/dist/ at publish
+// time. This test packs each tarball, extracts it, and runs the bin
+// from the extracted location to verify the npm layout is self-contained.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..", "..");
+
+function ensureMoonReleaseBuild() {
+  const sentinel = path.join(
+    ROOT,
+    "_build/js/release/build/mizchi/sol/cmd/sol/sol.js",
+  );
+  if (existsSync(sentinel)) return;
+  const r = spawnSync("moon", ["build", "--target", "js", "--release"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(
+    r.status,
+    0,
+    `moon build --release failed:\n${r.stdout}\n${r.stderr}`,
+  );
+}
+
+function packAndInstall(pkgDir, binName) {
+  const stage = mkdtempSync(path.join(tmpdir(), "luna-cli-pack-"));
+  const pack = spawnSync(
+    "pnpm",
+    ["pack", "--pack-destination", stage],
+    { cwd: pkgDir, encoding: "utf8" },
+  );
+  assert.equal(
+    pack.status,
+    0,
+    `pnpm pack failed in ${pkgDir}:\n${pack.stdout}\n${pack.stderr}`,
+  );
+  const tgz = readdirSync(stage).find((f) => f.endsWith(".tgz"));
+  assert.ok(tgz, `no .tgz produced under ${stage}`);
+
+  // Read-only inspection: extract a copy so the test can sanity-check
+  // dist/ before committing to the install round-trip.
+  const tar = spawnSync("tar", ["-xzf", path.join(stage, tgz), "-C", stage], {
+    encoding: "utf8",
+  });
+  assert.equal(tar.status, 0, `tar -xzf failed:\n${tar.stderr}`);
+  const extracted = path.join(stage, "package");
+  assert.ok(existsSync(extracted), `extracted root missing: ${extracted}`);
+
+  // Install the tarball into a fresh sandbox so runtime deps (colorette)
+  // resolve the same way they would on a `pnpm add -g` install.
+  const sandbox = path.join(stage, "sandbox");
+  mkdirSync(sandbox, { recursive: true });
+  const initPkg = JSON.stringify({ name: "luna-cli-sandbox", private: true });
+  writeFileSync(path.join(sandbox, "package.json"), initPkg);
+  const install = spawnSync(
+    "npm",
+    [
+      "install",
+      "--no-audit",
+      "--no-fund",
+      "--prefix",
+      sandbox,
+      path.join(stage, tgz),
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(
+    install.status,
+    0,
+    `npm install of ${tgz} failed:\n${install.stdout}\n${install.stderr}`,
+  );
+
+  const installedRoot = path.join(
+    sandbox,
+    "node_modules",
+    "@luna_ui",
+    binName === "sol" ? "sol" : "astra",
+  );
+  return {
+    extracted,
+    installedRoot,
+    cleanup: () => rmSync(stage, { recursive: true, force: true }),
+  };
+}
+
+test("@luna_ui/sol tarball contains a runnable CLI", { timeout: 240_000 }, () => {
+  ensureMoonReleaseBuild();
+  const { extracted, installedRoot, cleanup } = packAndInstall(
+    path.join(ROOT, "js/sol"),
+    "sol",
+  );
+  try {
+    const distEntry = path.join(extracted, "dist", "sol.js");
+    assert.ok(
+      existsSync(distEntry) && statSync(distEntry).size > 100_000,
+      `dist/sol.js is missing or suspiciously small at ${distEntry}`,
+    );
+
+    const binEntry = path.join(installedRoot, "bin", "sol.js");
+    const r = spawnSync(process.execPath, [binEntry, "--help"], {
+      encoding: "utf8",
+    });
+    assert.equal(
+      r.status,
+      0,
+      `sol --help failed:\nstdout=${r.stdout}\nstderr=${r.stderr}`,
+    );
+    assert.match(r.stdout, /Sol CLI/, `unexpected --help output: ${r.stdout}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test("@luna_ui/astra tarball contains a runnable CLI and bundled assets", { timeout: 240_000 }, () => {
+  ensureMoonReleaseBuild();
+  const { extracted, installedRoot, cleanup } = packAndInstall(
+    path.join(ROOT, "js/astra"),
+    "astra",
+  );
+  try {
+    const distEntry = path.join(extracted, "dist", "astra.js");
+    assert.ok(
+      existsSync(distEntry) && statSync(distEntry).size > 100_000,
+      `dist/astra.js is missing or suspiciously small at ${distEntry}`,
+    );
+
+    // astra's load_asset() reads styles/main.css and scripts/*.js at
+    // runtime; both must ship inside the tarball or the docs build
+    // falls back to a 143-byte stub stylesheet (see PR #47).
+    const mainCss = path.join(extracted, "dist", "assets", "styles", "main.css");
+    assert.ok(
+      existsSync(mainCss) && statSync(mainCss).size > 10_000,
+      `dist/assets/styles/main.css missing or too small at ${mainCss}`,
+    );
+    for (const script of ["loader.js", "theme.js", "sidebar.js", "toc.js"]) {
+      const p = path.join(extracted, "dist", "assets", "scripts", script);
+      assert.ok(existsSync(p), `dist/assets/scripts/${script} missing`);
+    }
+
+    const binEntry = path.join(installedRoot, "bin", "astra.js");
+    const r = spawnSync(process.execPath, [binEntry, "--help"], {
+      encoding: "utf8",
+    });
+    assert.equal(
+      r.status,
+      0,
+      `astra --help failed:\nstdout=${r.stdout}\nstderr=${r.stderr}`,
+    );
+    assert.match(r.stdout, /astra/, `unexpected --help output: ${r.stdout}`);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- `pnpm add -g @luna_ui/sol` and `@luna_ui/astra` were broken in 0.17.0: the bin shims imported the workspace `_build/` tree directly, so installs outside the monorepo crashed with `ERR_MODULE_NOT_FOUND`.
- `js/{sol,astra}/scripts/build-release.mjs` now copies the moonbit JS (and astra's runtime asset directory) into `js/<pkg>/dist/`. Wired into each package's `build` and `prepack` scripts, so `pnpm -r build` (which `publish.yml` already runs before `npm publish`) populates `dist/` automatically.
- Bin shims prefer `dist/` at runtime and fall back to workspace `_build/` so the existing monorepo-dev path (used by `tests/integration/website-*.test.js`) keeps working.
- Drops the `release-as: \"0.17.0\"` pins in `release-please-config.json`. They were a one-shot bootstrap; leaving them in blocks every future bump.

## Test plan

- [x] `pnpm test:integration` — 13/13 pass, including new `tests/integration/npm-cli-pack.test.js` (pack → install → \`--help\` round-trip for both packages)
- [x] `just check` — 0 errors
- [x] Manual repro: `node js/sol/bin/sol.js --help` and `node js/astra/bin/astra.js --help` work both before and after `pnpm -r build`
- [ ] After merge: dispatch `release-please.yml` to open the Release PR; expect `@luna_ui/sol` and `@luna_ui/astra` bumped to 0.17.1 from the \`fix:\` commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)