### PR TITLE
fix: align all @luna_ui npm package versions at 0.20.0

### DIFF
--- a/js/astra/package.json
+++ b/js/astra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/astra",
-  "version": "0.17.1",
+  "version": "0.20.0",
   "private": false,
   "type": "module",
   "bin": {

--- a/js/components/package.json
+++ b/js/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/components",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "Headless UI components matching src/components APG patterns",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/loader/package.json
+++ b/js/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/luna-loader",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "Island loader for Luna SSR hydration",
   "type": "module",
   "main": "./dist/loader.js",

--- a/js/luna/package.json
+++ b/js/luna/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/luna",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "Fine-grained reactive UI library for Moonbit/JS",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/sol/package.json
+++ b/js/sol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/sol",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "private": false,
   "type": "module",
   "bin": {

--- a/js/stella/package.json
+++ b/js/stella/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/stella",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "Stella CLI - Web Components generator for Luna",
   "type": "module",
   "bin": {

--- a/js/testing/package.json
+++ b/js/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/testing",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "Testing utilities for Luna UI components",
   "type": "module",
   "main": "./dist/index.js",

--- a/js/wcr/package.json
+++ b/js/wcr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luna_ui/wcr",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "Web Components Runtime for Luna UI",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Trigger commit for the 0.20.0 npm alignment. PR #53 set \`release-as: \"0.20.0\"\` in \`release-please-config.json\`, but release-please's \"build candidate per path\" pass skips packages with zero commits in their path since the last release tag — even with release-as forcing a version. This PR gives each \`js/<pkg>/\` path one commit so release-please recognizes them as releasable, then release-as pins them all at 0.20.0.

## Test plan

- [x] Each \`js/<pkg>/package.json\` bumped to 0.20.0 directly
- [ ] After merge: dispatch release-please → expect Release PR aligning all 8 packages at 0.20.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)