### PR TITLE
chore: post-0.20.0 cleanup (luna deps + release-as pins)

### DIFF
--- a/astra/examples/sol_blog/moon.mod.json
+++ b/astra/examples/sol_blog/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/sol": {
       "path": "../../../sol"
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/astra/examples/sol_docs/moon.mod.json
+++ b/astra/examples/sol_docs/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/sol": {
       "path": "../../../sol"
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/astra/moon.mod.json
+++ b/astra/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "mizchi/astra",
   "version": "0.20.0",
   "deps": {
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/markdown": "0.4.7",
     "mizchi/js": "0.10.15",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,13 +5,13 @@
   "separate-pull-requests": false,
   "plugins": ["node-workspace"],
   "packages": {
-    "js/luna":        { "package-name": "@luna_ui/luna",        "release-as": "0.20.0" },
-    "js/sol":         { "package-name": "@luna_ui/sol",         "release-as": "0.20.0" },
-    "js/astra":       { "package-name": "@luna_ui/astra",       "release-as": "0.20.0" },
-    "js/components":  { "package-name": "@luna_ui/components",  "release-as": "0.20.0" },
-    "js/loader":      { "package-name": "@luna_ui/luna-loader", "release-as": "0.20.0" },
-    "js/stella":      { "package-name": "@luna_ui/stella",      "release-as": "0.20.0" },
-    "js/testing":     { "package-name": "@luna_ui/testing",     "release-as": "0.20.0" },
-    "js/wcr":         { "package-name": "@luna_ui/wcr",         "release-as": "0.20.0" }
+    "js/luna":        { "package-name": "@luna_ui/luna" },
+    "js/sol":         { "package-name": "@luna_ui/sol" },
+    "js/astra":       { "package-name": "@luna_ui/astra" },
+    "js/components":  { "package-name": "@luna_ui/components" },
+    "js/loader":      { "package-name": "@luna_ui/luna-loader" },
+    "js/stella":      { "package-name": "@luna_ui/stella" },
+    "js/testing":     { "package-name": "@luna_ui/testing" },
+    "js/wcr":         { "package-name": "@luna_ui/wcr" }
   }
 }

--- a/sol/examples/sol_api/moon.mod.json
+++ b/sol/examples/sol_api/moon.mod.json
@@ -5,7 +5,7 @@
     "mizchi/sol": {
       "path": "../.."
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/sol/examples/sol_app/moon.mod.json
+++ b/sol/examples/sol_app/moon.mod.json
@@ -5,7 +5,7 @@
     "mizchi/sol": {
       "path": "../.."
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/sol/examples/sol_auth/moon.mod.json
+++ b/sol/examples/sol_auth/moon.mod.json
@@ -5,7 +5,7 @@
     "mizchi/sol": {
       "path": "../.."
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/sol/examples/sol_sqlite/moon.mod.json
+++ b/sol/examples/sol_sqlite/moon.mod.json
@@ -5,7 +5,7 @@
     "mizchi/sol": {
       "path": "../.."
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/sol/examples/sol_todo/moon.mod.json
+++ b/sol/examples/sol_todo/moon.mod.json
@@ -5,7 +5,7 @@
     "mizchi/sol": {
       "path": "../.."
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "mizchi/mars": "0.3.10",
     "mizchi/signals": "0.6.4",
     "mizchi/js": "0.10.15",

--- a/sol/moon.mod.json
+++ b/sol/moon.mod.json
@@ -7,7 +7,7 @@
       "path": "../astra",
       "version": "0.20.0"
     },
-    "mizchi/luna": "0.18.3",
+    "mizchi/luna": "0.20.0",
     "moonbitlang/async": "0.17.0",
     "moonbitlang/x": "0.4.41",
     "moonbitlang/parser": "0.2.5",


### PR DESCRIPTION
## Summary

Two cleanup tasks left over from the 0.20.0 alignment rollout:

1. **Bump \`mizchi/luna\` deps to 0.20.0** in \`sol/moon.mod.json\`, \`astra/moon.mod.json\`, and all 7 example projects. Previously pinned at 0.18.3 because luna 0.20.0 wasn't on the mooncakes registry yet at PR #53 merge time. luna 0.20.0 is now published, so the pins drop.
2. **Strip \`release-as: \"0.20.0\"\`** from \`release-please-config.json\`. Same one-shot bootstrap as the 0.17.0 alignment — needed it to force the synchronized release, but leaving it in blocks every future bump from conventional-commit detection.

## Test plan

- [x] \`moon update && just check\` — 0 errors after the dep bumps
- [x] \`pnpm test:integration\` — 12/12 pass (examples_matrix exercises the bumped luna dep in all 7 example projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)