### PR TITLE
docs(website): add Astra chapter

### DIFF
--- a/website/03_astra/01_getting-started.ja.md
+++ b/website/03_astra/01_getting-started.ja.md
@@ -1,0 +1,77 @@
+---
+title: はじめる
+description: Astra のインストール、初回プロジェクト作成、ビルド
+---
+
+# はじめる
+
+## 前提
+
+- MoonBit ツールチェーン (`moon`)
+- CLI として `moon install mizchi/astra/cmd/astra` または `pnpm add -g @luna_ui/astra`
+
+npm ラッパーは、Node.js は入っているが MoonBit ツールチェーンが無い場合のために用意されています。どちらの経路でも `$PATH` には同じバイナリが入ります。
+
+## プロジェクト構成
+
+Astra はコンテンツツリーを `docs/` から読みます（`astra.config.json` の `docs_dir` で変更可）:
+
+```
+my-docs/
+├── astra.config.json     # 省略可。小規模なら無くても動く
+├── docs/
+│   ├── index.md          # → /
+│   └── guide/
+│       ├── index.md      # → /guide/
+│       └── routing.md    # → /guide/routing/
+└── dist/                 # → astra build の出力先（gitignore）
+```
+
+最小限の `astra.config.json`:
+
+```json
+{
+  "title": "My Docs",
+  "docs_dir": "docs",
+  "output_dir": "dist"
+}
+```
+
+省略したフィールドは `@astra.SsgConfig::default()` のデフォルト値が使われます。
+
+## 最初のページ
+
+`docs/index.md`:
+
+```md
+---
+title: ようこそ
+---
+
+# ようこそ
+
+このページは Astra が描画しています。
+```
+
+frontmatter の `title` はページの `<title>` と、自動生成サイドバーの両方に反映されます。
+
+## ビルド
+
+```sh
+astra build --out ./dist
+```
+
+ミドルウェアが公開するすべての URL（Markdown ページ + バンドルアセット）をクロールし、各ページについて `<out>/<url>/index.html` を生成。アセットツリー (`/assets/main.css`、`/scripts/loader.js` など) も同じ `<out>/` 直下に書き出されます。
+
+## dev サーバー
+
+```sh
+astra dev --port 7777
+```
+
+dev サーバーは build と同じ `Middleware::handler()` を経由するので、`http://localhost:7777` でブラウザに表示される内容と、`astra build` がディスクに書く内容は同一です。レンダラーが分裂しません。
+
+## 次
+
+- [Mars にマウントする](/ja/astra/mount-on-mars/) — 既存の Mars サーバーに組み込む
+- [デプロイ](/ja/astra/deploy/) — ビルド出力を配信する

--- a/website/03_astra/01_getting-started.md
+++ b/website/03_astra/01_getting-started.md
@@ -1,0 +1,77 @@
+---
+title: Getting Started
+description: Install Astra, create your first docs project, and run the build
+---
+
+# Getting Started
+
+## Prerequisites
+
+- MoonBit toolchain (`moon`)
+- Either `moon install mizchi/astra/cmd/astra` or `pnpm add -g @luna_ui/astra` for the CLI
+
+The npm wrapper exists for users who already have Node.js but not the MoonBit toolchain — both end up with the same binary on `$PATH`.
+
+## Project layout
+
+Astra reads its content tree from `docs/` (or whatever `docs_dir` points at in `astra.config.json`):
+
+```
+my-docs/
+├── astra.config.json     # optional — defaults work for a small site
+├── docs/
+│   ├── index.md          # → /
+│   └── guide/
+│       ├── index.md      # → /guide/
+│       └── routing.md    # → /guide/routing/
+└── dist/                 # → astra build output (gitignored)
+```
+
+A minimum `astra.config.json`:
+
+```json
+{
+  "title": "My Docs",
+  "docs_dir": "docs",
+  "output_dir": "dist"
+}
+```
+
+If a config field is omitted, Astra uses its defaults (defined in `@astra.SsgConfig::default()`).
+
+## First page
+
+`docs/index.md`:
+
+```md
+---
+title: Welcome
+---
+
+# Welcome
+
+This is rendered by Astra.
+```
+
+The frontmatter `title` flows into the page's `<title>` and the auto-generated sidebar.
+
+## Build
+
+```sh
+astra build --out ./dist
+```
+
+This crawls every URL the middleware exposes (every Markdown page plus bundled assets) and writes `<out>/<url>/index.html` for each page, alongside the asset tree (`/assets/main.css`, `/scripts/loader.js`, etc.).
+
+## Dev server
+
+```sh
+astra dev --port 7777
+```
+
+The dev server uses the same `Middleware::handler()` as the build, so what you see in the browser at `http://localhost:7777` is what `astra build` will write to disk. There is no second renderer.
+
+## Next
+
+- [Mount on Mars](/astra/mount-on-mars/) — embed Astra in an existing Mars server
+- [Deploy](/astra/deploy/) — ship the build output

--- a/website/03_astra/02_mount-on-mars.ja.md
+++ b/website/03_astra/02_mount-on-mars.ja.md
@@ -1,0 +1,68 @@
+---
+title: Mars にマウントする
+description: 既存の Mars サーバーに Astra をミドルウェアとして組み込む
+---
+
+# Mars にマウントする
+
+`astra build` がクロールするのと同じ `Middleware` インスタンスを、任意の Mars サーバーにマウントできます。これにより、1 つの MoonBit バイナリで稼働中のアプリケーションとドキュメントを同時に配信できます。
+
+## 最小構成
+
+```moonbit
+import "mizchi/astra" as astra
+import "mizchi/astra/middleware" as middleware
+import "mizchi/mars" as mars
+
+async fn main {
+  let cfg = @astra.SsgConfig::default()
+  let mw  = @middleware.create(cfg, cwd=".")
+
+  let app = @mars.Server::new()
+  app.all("/*", mw.handler())
+  app.listen(port=3000)
+}
+```
+
+`Middleware::handler()` は Mars の `Handler` を返します。ドキュメントツリーが公開するすべてのページ URL と、`@assets.list_asset_urls()` のすべてのエントリに対する GET に応答します。`Middleware::list_urls()` はその和集合を返し、ビルドクローラーが歩くのと同じ集合です。
+
+## パス prefix でのマウント
+
+ドキュメントを `/docs/*` に配置するには、`/*` の代わりに Mars のパス prefix ルーティングを使います:
+
+```moonbit
+let app = @mars.Server::new()
+app.all("/api/*", api_handler())          // アプリのルート
+app.all("/docs/*", mw.handler())          // astra のドキュメント
+app.listen(port=3000)
+```
+
+`astra.config.json` で `base: "/docs/"` を設定すれば、生成 HTML 内のリンクがルートではなく prefix 付きのパスを指すようになります。
+
+## ミドルウェアが実際に配信するもの
+
+各リクエストで:
+
+1. URL を解決済みのページツリー (`docs_dir` の探索 + i18n フォールバック) と照合
+2. ヒットしたら Markdown / MDX をキャッシュ済みのドキュメントパイプラインで描画して HTML を返す
+3. ヒットしなければアセットリスト (`/assets/*.css`、`/scripts/*.js`、フォント、画像) を確認。ヒットしたらバンドル済みバイトを返す
+4. どれにもヒットしなければ 404
+
+別途、静的アセット用のミドルウェアを配線する必要はありません。astra がドキュメントを描画するために必要なものは、すべて `list_urls()` で列挙され、`handler()` で配信されます。
+
+## ビルドとの一致
+
+`astra build` は薄いループです:
+
+```moonbit
+for url in mw.list_urls() {
+  let response = @testing.invoke(mw.handler(), path=url)
+  write_to_disk(out, url, response.body)
+}
+```
+
+これが dev と build が常に一致する理由です。差異を見つけたらバグとして扱ってください。既知のギャップ（utility CSS 抽出、sitemap 生成、Cloudflare adapter マニフェストなど）は [`astra/docs/parity-notes.md`](https://github.com/mizchi/luna.mbt/blob/main/astra/docs/parity-notes.md) で追跡しています。
+
+## ホットリロード
+
+`astra dev` は `docs_dir` を監視し、変更時にドキュメントツリーのリビジョンを更新します。次のリクエストでミドルウェアが新しいリビジョンを見て再レンダリング。dev パスでは MoonBit の再コンパイルは発生せず、Markdown の変更はレンダラーが走る速度で反映されます。

--- a/website/03_astra/02_mount-on-mars.md
+++ b/website/03_astra/02_mount-on-mars.md
@@ -1,0 +1,68 @@
+---
+title: Mount on Mars
+description: Embed Astra as middleware in an existing Mars server
+---
+
+# Mount on Mars
+
+The same `Middleware` instance that `astra build` crawls can be mounted on any Mars server. This is how you ship documentation alongside a live MoonBit application from one binary.
+
+## Minimal mount
+
+```moonbit
+import "mizchi/astra" as astra
+import "mizchi/astra/middleware" as middleware
+import "mizchi/mars" as mars
+
+async fn main {
+  let cfg = @astra.SsgConfig::default()
+  let mw  = @middleware.create(cfg, cwd=".")
+
+  let app = @mars.Server::new()
+  app.all("/*", mw.handler())
+  app.listen(port=3000)
+}
+```
+
+`Middleware::handler()` returns a Mars `Handler` that responds to GET on every page URL the document tree exposes plus every entry in `@assets.list_asset_urls()`. `Middleware::list_urls()` returns the union of those — that is the same set the build crawler walks.
+
+## Mounting under a path prefix
+
+To embed docs under `/docs/*`, use Mars's path prefix routing instead of `/*`:
+
+```moonbit
+let app = @mars.Server::new()
+app.all("/api/*", api_handler())          // your application
+app.all("/docs/*", mw.handler())          // astra-served docs
+app.listen(port=3000)
+```
+
+Configure `base: "/docs/"` in `astra.config.json` so links inside generated HTML point at the prefixed paths instead of the root.
+
+## What the middleware actually serves
+
+For each request:
+
+1. Look up the URL in the resolved page tree (`docs_dir` walk + i18n fallback).
+2. If hit, render the Markdown / MDX through the cached document pipeline and return HTML.
+3. Otherwise, check the asset list (`/assets/*.css`, `/scripts/*.js`, fonts, images). If hit, return the bundled bytes.
+4. Otherwise, return 404.
+
+There is no separate static-asset middleware to wire up. Everything astra needs to render the docs is enumerated by `list_urls()` and served by `handler()`.
+
+## Build parity
+
+`astra build` is a thin loop:
+
+```moonbit
+for url in mw.list_urls() {
+  let response = @testing.invoke(mw.handler(), path=url)
+  write_to_disk(out, url, response.body)
+}
+```
+
+This is why dev and build always agree. If you find a divergence, treat it as a bug — see [`astra/docs/parity-notes.md`](https://github.com/mizchi/luna.mbt/blob/main/astra/docs/parity-notes.md) for known gaps (utility CSS extraction, sitemap generation, Cloudflare adapter manifests).
+
+## Hot reload
+
+`astra dev` watches `docs_dir` and bumps the document tree's revision on change. The middleware sees the new revision on the next request and re-renders. There is no MoonBit recompile in the dev path — Markdown changes are reflected as fast as the renderer runs.

--- a/website/03_astra/03_deploy.ja.md
+++ b/website/03_astra/03_deploy.ja.md
@@ -1,0 +1,75 @@
+---
+title: デプロイ
+description: astra build の出力を GitHub Pages / Cloudflare / Vercel / Netlify に配信する
+---
+
+# デプロイ
+
+`astra build` は自己完結したディレクトリを生成するので、任意の静的ホストにそのままデプロイできます。`astra.config.json` で `deploy` を指定すると、HTML と一緒にプラットフォーム固有の設定ファイルが書き出されます。
+
+## 設定
+
+```json
+{
+  "deploy": "github-pages"
+}
+```
+
+実行:
+
+```sh
+astra build --out ./dist
+```
+
+## 対応プラットフォーム
+
+| プラットフォーム | `deploy` の値 | 生成されるファイル |
+|------------------|---------------|--------------------|
+| 静的（デフォルト） | `static` | なし |
+| Cloudflare Pages / Workers | `cloudflare` | `_routes.json` |
+| GitHub Pages | `github-pages` または `github` | `.nojekyll`、`CNAME`（指定時） |
+| Vercel | `vercel` | `vercel.json` |
+| Netlify | `netlify` | `_headers`、`_redirects` |
+| Deno Deploy | `deno` | なし（そのまま配信される） |
+| Node.js | `node` | なし |
+
+## GitHub Pages
+
+```json
+{
+  "deploy": "github-pages",
+  "base": "/my-repo/",
+  "github": {
+    "repo": "mizchi/my-repo",
+    "branch": "gh-pages"
+  }
+}
+```
+
+GitHub Pages はユーザー / 組織サイトを `/<repo>/` 配下で配信するため、`base` をリポジトリパスに合わせる必要があります。`.nojekyll` が出力されるので、`_` で始まるファイル（`_astro` チャンクなど）が除外されません。
+
+## Cloudflare Pages
+
+```json
+{
+  "deploy": "cloudflare",
+  "base": "/"
+}
+```
+
+Cloudflare のエッジランタイムが静的 / 動的パスを区別できるよう `_routes.json` が出力されます。同じ出力に Functions を共存させても衝突しません。
+
+## 検索インデックス (pagefind)
+
+Astra 自体は検索インデックスを生成しません。全文検索が必要なら、ビルド出力に対して pagefind を走らせます:
+
+```sh
+astra build --out ./dist
+pnpm exec pagefind --site ./dist
+```
+
+pagefind が生成する `dist/pagefind/` は、バンドル済み `<pagefind-ui>` コンポーネントが実行時に読み込むディレクトリです。Luna のドキュメントサイトはデプロイ前の CI でこれを実行しています — パターンは [`.github/workflows/deploy-website.yml`](https://github.com/mizchi/luna.mbt/blob/main/.github/workflows/deploy-website.yml) を参照。
+
+## デプロイ前の検証
+
+Luna リポジトリの `tests/integration/website-asset-integrity.test.js` は、ビルド出力のすべての HTML をクロールし、ローカル参照 (`src` / `href`) を解析して、各リソースの存在を検証します。同じパターンを自分のサイトに対して走らせれば、リンク切れアセットがデプロイ前に検出できます。

--- a/website/03_astra/03_deploy.md
+++ b/website/03_astra/03_deploy.md
@@ -1,0 +1,75 @@
+---
+title: Deploy
+description: Ship the astra build output to GitHub Pages, Cloudflare, Vercel, Netlify
+---
+
+# Deploy
+
+`astra build` produces a self-contained directory you can deploy to any static host. Setting `deploy` in `astra.config.json` makes Astra emit platform-specific configuration files alongside the HTML.
+
+## Configuration
+
+```json
+{
+  "deploy": "github-pages"
+}
+```
+
+Then:
+
+```sh
+astra build --out ./dist
+```
+
+## Supported platforms
+
+| Platform | `deploy` value | Generated files |
+|----------|----------------|-----------------|
+| Static (default) | `static` | None |
+| Cloudflare Pages / Workers | `cloudflare` | `_routes.json` |
+| GitHub Pages | `github-pages` or `github` | `.nojekyll`, `CNAME` (if set) |
+| Vercel | `vercel` | `vercel.json` |
+| Netlify | `netlify` | `_headers`, `_redirects` |
+| Deno Deploy | `deno` | None — files served as-is |
+| Node.js | `node` | None |
+
+## GitHub Pages
+
+```json
+{
+  "deploy": "github-pages",
+  "base": "/my-repo/",
+  "github": {
+    "repo": "mizchi/my-repo",
+    "branch": "gh-pages"
+  }
+}
+```
+
+`base` must match the repository path because GitHub Pages serves user/org sites under `/<repo>/`. The build emits `.nojekyll` so files starting with `_` (like `_astro` chunks) are not stripped.
+
+## Cloudflare Pages
+
+```json
+{
+  "deploy": "cloudflare",
+  "base": "/"
+}
+```
+
+Astra emits `_routes.json` so Cloudflare's edge runtime knows which paths are static vs dynamic. Custom Functions can live alongside the static output without conflict.
+
+## Search index (pagefind)
+
+Astra does not generate a search index by itself. Run pagefind against the build output if you need full-text search:
+
+```sh
+astra build --out ./dist
+pnpm exec pagefind --site ./dist
+```
+
+The `dist/pagefind/` directory pagefind produces is what the bundled `<pagefind-ui>` component reads at runtime. The Luna documentation site does this in CI before deploying — see [`.github/workflows/deploy-website.yml`](https://github.com/mizchi/luna.mbt/blob/main/.github/workflows/deploy-website.yml) for the pattern.
+
+## Verifying the build before deploy
+
+`tests/integration/website-asset-integrity.test.js` in the Luna repo crawls every HTML file in the build output, parses local `src` / `href` references, and asserts each one exists. Running that test pattern against your own site catches broken asset links before the deploy.

--- a/website/03_astra/index.ja.md
+++ b/website/03_astra/index.ja.md
@@ -1,0 +1,69 @@
+---
+title: Astra
+description: MoonBit 製の静的サイトジェネレーター用 Mars ミドルウェア
+---
+
+# Astra
+
+> **Experimental**: Astra は活発に開発中で、API は変わる可能性があります。
+
+Astra は MoonBit 用の [Mars](https://mooncakes.io/docs/mizchi/mars/) にマウント可能な静的サイト生成ミドルウェアです。Markdown / MDX のドキュメントページをリクエスト時にレンダリングし、loader ランタイム、デフォルト CSS、Shiki シンタックスハイライトなどのバンドル済みアセットを配信します。`astra` CLI と組み合わせれば、同じ出力を静的ツリーとしてダンプ (`astra build`) したり、dev サーバーから配信 (`astra dev`) したりできます。
+
+## Astra の特徴
+
+ミドルウェア配信と静的ダンプは、**同じ** `Middleware::handler()` を経由します。ビルドクローラーは、ミドルウェアが公開する各 URL に対して `@testing.invoke(handler, path=url)` を呼び、レスポンスボディをディスクに書き出すだけ。`astra dev` で正しく描画されるページは、静的ダンプでも必ず同じ結果になります。レンダラーが二系統に分かれる心配がありません。
+
+この性質によって、Astra には 2 つの使い方があります:
+
+- **ライブラリ**: 既存の Mars サーバーにアプリのルートと並べてマウント。同じ MoonBit バイナリで `/docs/*` のドキュメントと、ライブの API エンドポイントを同時に提供できます。
+- **静的サイト**: サーバーを使わず、`astra build --out ./dist` で自己完結したディレクトリを生成。GitHub Pages、Cloudflare、Vercel、Netlify などの静的ホストにそのままデプロイできます。
+
+## Sol との使い分け
+
+| 用途 | 選ぶもの |
+|------|----------|
+| 主に静的なドキュメント / ブログ | **Astra** |
+| 既存の Mars アプリに組み込むドキュメント | **Astra**（ミドルウェアとしてマウント） |
+| ファイルベースルーティング、API ルート、サーバーアクションを伴うフル SSR | [**Sol**](/ja/sol/) |
+| 1 リポジトリで両方 | Sol + `/docs/*` 配下に Astra をマウント |
+
+Astra は Sol に依存しません。`deps: mars + markdown + luna` のみ。Sol はドキュメント生成に Astra を取り込みますが、その逆は成立しません。
+
+## セクション
+
+- [はじめる](/ja/astra/getting-started/) — インストール、最初のプロジェクト、最初のビルド
+- [Mars にマウントする](/ja/astra/mount-on-mars/) — 既存の Mars サーバーへの組み込み方
+- [デプロイ](/ja/astra/deploy/) — GitHub Pages / Cloudflare / Vercel / Netlify
+
+## インストール
+
+ライブラリ:
+
+```jsonc
+// moon.mod.json
+{
+  "deps": {
+    "mizchi/astra": "0.20.0",
+    "mizchi/mars": "0.3.10",
+    "mizchi/luna": "0.20.0"
+  }
+}
+```
+
+CLI:
+
+```sh
+moon install mizchi/astra/cmd/astra   # → $MOON_HOME/bin/astra
+# moon は無いが node がある場合
+pnpm add -g @luna_ui/astra
+```
+
+## さわってみる
+
+```bash
+mkdir docs && echo "# Hello Astra" > docs/index.md
+astra build --out ./dist
+# dist/index.html にページが書き出される
+```
+
+i18n、MDX、ブログ、コンポーネントを使ったフル機能の例は、ソースリポジトリの [`astra/examples/sol_docs/`](https://github.com/mizchi/luna.mbt/tree/main/astra/examples/sol_docs) にあります。

--- a/website/03_astra/index.md
+++ b/website/03_astra/index.md
@@ -1,0 +1,69 @@
+---
+title: Astra
+description: Mountable Mars middleware for static-site generation in MoonBit
+---
+
+# Astra
+
+> **Experimental**: Astra is under active development. APIs may change.
+
+Astra is a mountable [Mars](https://mooncakes.io/docs/mizchi/mars/) middleware for static-site generation in MoonBit. It renders Markdown / MDX documentation pages on request and serves bundled assets (loader runtime, default CSS, Shiki syntax highlighting). Pair it with the `astra` CLI to dump the same output as a static tree (`astra build`) or serve it from a dev server (`astra dev`).
+
+## What makes Astra different
+
+The middleware and the static dump go through the **same** `Middleware::handler()`. The build crawler calls `@testing.invoke(handler, path=url)` for each entry the middleware exposes and writes the response body to disk. So if a page renders correctly via `astra dev`, it is also correct in the static dump — there is no second renderer to keep in sync.
+
+That property gives Astra two postures:
+
+- **Library**: mount on any Mars server alongside your application routes. The same MoonBit app can serve a `/docs/*` documentation tree and live API endpoints from one binary.
+- **Static site**: skip the server entirely. `astra build --out ./dist` produces a self-contained directory you can ship to GitHub Pages, Cloudflare, Vercel, or any static host.
+
+## When to choose Astra over Sol
+
+| Need | Reach for |
+|------|-----------|
+| Docs / blog with mostly static content | **Astra** |
+| Embedded docs alongside an existing Mars app | **Astra** (mounted as middleware) |
+| Full SSR app with file-based routing, API routes, server actions | [**Sol**](/sol/) |
+| Both, in one repository | Sol with Astra mounted under `/docs/*` |
+
+Astra has no edge to Sol — `deps: mars + markdown + luna`. Sol pulls Astra in for its docs surface but the inverse is not true.
+
+## Sections
+
+- [Getting Started](/astra/getting-started/) — install, first project, first build
+- [Mount on Mars](/astra/mount-on-mars/) — embed Astra in an existing Mars server
+- [Deploy](/astra/deploy/) — GitHub Pages, Cloudflare, Vercel, Netlify
+
+## Install
+
+Library:
+
+```jsonc
+// moon.mod.json
+{
+  "deps": {
+    "mizchi/astra": "0.20.0",
+    "mizchi/mars": "0.3.10",
+    "mizchi/luna": "0.20.0"
+  }
+}
+```
+
+CLI:
+
+```sh
+moon install mizchi/astra/cmd/astra   # → $MOON_HOME/bin/astra
+# or via npm if you have node but not moon
+pnpm add -g @luna_ui/astra
+```
+
+## Quick taste
+
+```bash
+mkdir docs && echo "# Hello Astra" > docs/index.md
+astra build --out ./dist
+# dist/index.html now renders the page
+```
+
+A full working example with i18n, MDX, blog, and components lives at [`astra/examples/sol_docs/`](https://github.com/mizchi/luna.mbt/tree/main/astra/examples/sol_docs) in the source repository.

--- a/website/sol.config.json
+++ b/website/sol.config.json
@@ -24,6 +24,7 @@
   "nav": [
     { "text": "Luna", "link": "/luna/", "icon": "luna" },
     { "text": "Sol", "link": "/sol/", "icon": "sol" },
+    { "text": "Astra", "link": "/astra/" },
     { "text": "Search", "link": "/search/", "icon": "search" }
   ],
   "sidebar": "auto",


### PR DESCRIPTION
## Summary

Astra was extracted from sol's old SSG capability into its own mooncake (\`mizchi/astra\`), but the website still only had Luna and Sol surfaces. This adds a dedicated \`/astra/\` chapter so the website matches the actual package layout.

Pages (en + ja):

- \`/astra/\` — overview, when to choose Astra over Sol, install
- \`/astra/getting-started/\` — project layout, first build, dev server
- \`/astra/mount-on-mars/\` — middleware semantics, path-prefix mounting, the build/dev parity property
- \`/astra/deploy/\` — supported targets, GitHub Pages, Cloudflare Pages, pagefind integration

\`sol.config.json\` nav gets an \"Astra\" entry between \"Sol\" and \"Search\".

## What this doesn't do

The pre-extraction \`/sol/ssg/\` chapter is still in tree and partially overlaps with what Astra now owns. Migrating or cross-linking that content is a bigger refactor — left for a follow-up so this PR stays focused on the additive chapter.

## Test plan

- [x] \`astra build --out /tmp/...\` against \`website/\` emits all 4 astra pages × 2 locales (URL count 139 → 147)
- [x] \`pnpm test:integration\` — 18/18 pass (incl. website-asset-integrity which would catch broken nav links / asset refs in the new pages)
- [x] Manually opened \`/tmp/.../astra/index.html\` and \`/tmp/.../ja/astra/index.html\`; nav contains the Astra entry, lang switcher cross-links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)