### PR TITLE
feat(luna): deploy examples to luna-examples.mizchi.workers.dev

### DIFF
--- a/.github/workflows/deploy-luna-examples.yml
+++ b/.github/workflows/deploy-luna-examples.yml
@@ -1,0 +1,55 @@
+name: deploy-luna-examples
+
+# Builds the static demo tree under luna/dist-demo (one HTML+JS per example
+# under luna/src/examples) and deploys it to luna-examples.mizchi.workers.dev
+# as a Cloudflare Workers Static Assets worker. No SSR runtime; pure CDN.
+#
+# Trigger: same as deploy-website — fires on luna-v* GitHub Releases (so each
+# release-please cycle deploys once, not once per package). workflow_dispatch
+# is the manual fallback.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'luna-v') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+
+      - run: moon update
+
+      - run: pnpm install --frozen-lockfile
+
+      # Examples emit to _build/js/release/build/mizchi/luna/examples/<id>/<id>.js.
+      - run: moon build --target js --release
+
+      - name: Build static demo tree
+        run: node luna/scripts/build-demo.mjs
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # accountId is set explicitly so wrangler skips the /memberships
+          # auto-detect call (which fails on tokens that lack
+          # User > Memberships:Read even when the deploy scope is fine).
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: luna
+          wranglerVersion: "4"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 dist/
 !js/loader/dist/
 dist-docs/
+dist-demo/
 _build/
 
 # Wrangler / Cloudflare Workers

--- a/luna/scripts/build-demo.mjs
+++ b/luna/scripts/build-demo.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Build a self-contained static tree of luna examples for Cloudflare Workers Static Assets.
+//
+// Output layout (luna/dist-demo/):
+//   index.html                 — landing page (rewritten from luna/index.html)
+//   <example>/index.html       — example HTML, with <script> rewritten to ./index.js
+//   <example>/index.js         — moonbit-built JS for the example
+//
+// Prereq: `moon build --target js --release` so artifacts exist at
+// _build/js/release/build/mizchi/luna/examples/<id>/<id>.js.
+import { readFile, writeFile, mkdir, copyFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const lunaRoot = resolve(__dirname, "..");
+const repoRoot = resolve(lunaRoot, "..");
+
+const buildSrc = join(
+  repoRoot,
+  "_build",
+  "js",
+  "release",
+  "build",
+  "mizchi",
+  "luna",
+  "examples",
+);
+const examplesSrc = join(lunaRoot, "src", "examples");
+const outDir = join(lunaRoot, "dist-demo");
+
+// css_split_test depends on Vite's `virtual:luna.css` plugin and is excluded
+// from the static bundle. wc_counter / wiki are not part of the landing page.
+const examples = [
+  {
+    id: "hello_luna",
+    title: "Hello Luna",
+    desc: "Basic Luna Web Components examples",
+  },
+  {
+    id: "todomvc",
+    title: "TodoMVC",
+    desc: "Classic TodoMVC implementation with Luna",
+  },
+  {
+    id: "spa",
+    title: "SPA Example",
+    desc: "Single Page Application with signals and reactive components",
+  },
+  {
+    id: "browser_router",
+    title: "Browser Router",
+    desc: "Client-side routing with dynamic parameters and nested routes",
+  },
+  {
+    id: "game",
+    title: "Game Demo",
+    desc: "Interactive game built with Luna's reactive primitives",
+  },
+  {
+    id: "wc",
+    title: "Web Components",
+    desc: "Luna components as custom elements with shadow DOM",
+  },
+  {
+    id: "apg-playground",
+    title: "APG Playground",
+    desc: "WAI-ARIA APG compliant UI components playground",
+  },
+];
+
+function rewriteExampleHtml(html) {
+  // Replace the inline <script>...loadModule(primaryModule)...</script>
+  // block with a single <script type="module" src="./index.js"></script>.
+  const pattern =
+    /<script>\s*const loadModule[\s\S]*?loadModule\(primaryModule\)[\s\S]*?<\/script>/;
+  if (!pattern.test(html)) {
+    throw new Error(
+      "loadModule(primaryModule) script block not found; example HTML format may have changed",
+    );
+  }
+  return html.replace(
+    pattern,
+    `<script type="module" src="./index.js"></script>`,
+  );
+}
+
+function rewriteLanding(html) {
+  // ./src/examples/<id>/  →  ./<id>/
+  let out = html.replace(
+    /href="\.\/src\/examples\/([^"\/]+)\//g,
+    'href="./$1/',
+  );
+  // Drop entries we don't ship (css_split_test).
+  out = out.replace(
+    /\s*<li class="demo-item">\s*<a href="\.\/css_split_test\/"[\s\S]*?<\/li>/,
+    "",
+  );
+  return out;
+}
+
+async function main() {
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  for (const ex of examples) {
+    const jsSrc = join(buildSrc, ex.id, `${ex.id}.js`);
+    const htmlSrc = join(examplesSrc, ex.id, "index.html");
+    if (!existsSync(jsSrc)) {
+      throw new Error(
+        `Missing build artifact: ${jsSrc}\nRun \`moon build --target js --release\` first.`,
+      );
+    }
+    if (!existsSync(htmlSrc)) {
+      throw new Error(`Missing example HTML: ${htmlSrc}`);
+    }
+
+    const dest = join(outDir, ex.id);
+    await mkdir(dest, { recursive: true });
+    await copyFile(jsSrc, join(dest, "index.js"));
+
+    const html = await readFile(htmlSrc, "utf8");
+    await writeFile(join(dest, "index.html"), rewriteExampleHtml(html));
+  }
+
+  const landing = await readFile(join(lunaRoot, "index.html"), "utf8");
+  await writeFile(join(outDir, "index.html"), rewriteLanding(landing));
+
+  console.log(
+    `built ${examples.length} examples + landing → ${outDir.replace(repoRoot + "/", "")}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/luna/wrangler.json
+++ b/luna/wrangler.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../node_modules/wrangler/config-schema.json",
+  "name": "luna-examples",
+  "compatibility_date": "2025-10-01",
+  "assets": {
+    "directory": "./dist-demo",
+    "not_found_handling": "404-page"
+  },
+  "observability": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `luna/scripts/build-demo.mjs` which assembles `luna/dist-demo/` from the moonbit-built artifacts at `_build/js/release/build/mizchi/luna/examples/<id>/<id>.js`. Each example becomes a self-contained `<id>/index.html` + `<id>/index.js` pair, with the inline `loadModule()` block rewritten to a single `<script type="module" src="./index.js">`. The landing page is rewritten from `luna/index.html` so it links to `./<id>/` directly.
- Adds `luna/wrangler.json` for the existing `luna-examples` worker (assets pointed at `./dist-demo`, `not_found_handling: 404-page`).
- Adds `.github/workflows/deploy-luna-examples.yml` — same gating shape as `deploy-website.yml`: fires on `luna-v*` releases (so a release-please cycle deploys once, not 8 times) and `workflow_dispatch` is the manual fallback.
- 7 examples ship: `hello_luna`, `todomvc`, `spa`, `browser_router`, `game`, `wc`, `apg-playground`. `css_split_test` is excluded because it depends on Vite's `virtual:luna.css` plugin and needs a different build path; `wc_counter`/`wiki` weren't on the landing.

The existing `luna-examples.mizchi.workers.dev` will be overwritten by the first deploy after merge.

## Test plan
- [x] `node luna/scripts/build-demo.mjs` produces `luna/dist-demo/` with 7 example dirs + `index.html` (1.7 MB total)
- [x] Local `python3 -m http.server` smoke: landing 200, `/spa/` 200, `/spa/index.js` 200 (162 KB)
- [ ] Deploy via `workflow_dispatch` after merge and verify `https://luna-examples.mizchi.workers.dev/spa/` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)