### PR TITLE
fix(luna): rewrite browser_router base path for luna-examples worker

### DIFF
--- a/luna/scripts/build-demo.mjs
+++ b/luna/scripts/build-demo.mjs
@@ -8,7 +8,7 @@
 //
 // Prereq: `moon build --target js --release` so artifacts exist at
 // _build/js/release/build/mizchi/luna/examples/<id>/<id>.js.
-import { readFile, writeFile, mkdir, copyFile, rm } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -118,7 +118,15 @@ async function main() {
 
     const dest = join(outDir, ex.id);
     await mkdir(dest, { recursive: true });
-    await copyFile(jsSrc, join(dest, "index.js"));
+    let js = await readFile(jsSrc, "utf8");
+    if (ex.id === "browser_router") {
+      // The example hard-codes `let base = "/demo/browser_router"` for vite
+      // dev where vite.config.ts mounts at base "/demo/". On the
+      // luna-examples worker the route prefix is "/browser_router". Patching
+      // the compiled JS keeps the source compatible with vite dev.
+      js = js.replace(/"\/demo\/browser_router"/g, '"/browser_router"');
+    }
+    await writeFile(join(dest, "index.js"), js);
 
     const html = await readFile(htmlSrc, "utf8");
     await writeFile(join(dest, "index.html"), rewriteExampleHtml(html));


### PR DESCRIPTION
## Summary

Browser test on `https://luna-examples.mizchi.workers.dev/browser_router/` showed the page rendering "404 - Not Found" because all client-side links pointed to `/demo/browser_router/...` instead of `/browser_router/...`.

Root cause: `luna/src/examples/browser_router/main.mbt:481` hard-codes `let base = "/demo/browser_router"` for the vite dev path (where `vite.config.ts` mounts examples under `base: "/demo/"`). On the luna-examples worker the prefix is `/browser_router`, so the router rejects every URL.

Fix: in `luna/scripts/build-demo.mjs`, rewrite the literal `"/demo/browser_router"` → `"/browser_router"` in the built JS only for that example. Source stays valid for vite dev. Verified locally: `grep "/demo/browser_router"` is 0 in the rebuilt artifact.

Other 6 examples checked via DOM/computed-style probes against the live worker — all CSS rendered correctly, custom elements registered, moonbit-rendered DOM intact.

## Test plan
- [x] `node luna/scripts/build-demo.mjs` rewrites the literal in `luna/dist-demo/browser_router/index.js` only
- [ ] After merge + deploy: visit `/browser_router/` and confirm Home view renders, links go to `/browser_router/about` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)