### PR TITLE
test(astra): deploy smoke for Luna UI website

### DIFF
--- a/astra/e2e/deployed/playwright.config.mts
+++ b/astra/e2e/deployed/playwright.config.mts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Smoke tests against the deployed Luna UI website. Defaults to the
+// canonical Cloudflare Workers deploy; override with WEBSITE_URL to point
+// at the GitHub Pages mirror or a preview build.
+//
+// Examples:
+//   pnpm exec playwright test --config=astra/e2e/deployed/playwright.config.mts
+//   WEBSITE_URL=https://mizchi.github.io/luna.mbt pnpm exec playwright test \
+//     --config=astra/e2e/deployed/playwright.config.mts
+const baseURL =
+  process.env.WEBSITE_URL ?? "https://luna.mizchi.workers.dev";
+
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: ["**/*.test.ts"],
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "dot",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+});

--- a/astra/e2e/deployed/website.test.ts
+++ b/astra/e2e/deployed/website.test.ts
@@ -1,0 +1,100 @@
+// Smoke tests for the deployed Luna UI website (built by `astra build`).
+//
+// Default target: https://luna.mizchi.workers.dev (Cloudflare Workers).
+// Override WEBSITE_URL to point at https://mizchi.github.io/luna.mbt
+// (GitHub Pages mirror) or any preview build.
+//
+// Run:
+//   pnpm exec playwright test --config=astra/e2e/deployed/playwright.config.mts
+import { test, expect } from "@playwright/test";
+
+const PAGES = [
+  { path: "/", title: "Luna UI" },
+  { path: "/introduction/overview/" },
+  { path: "/luna/", title: /Luna/ },
+  { path: "/sol/", title: /Sol/ },
+  { path: "/astra/", title: /Astra/ },
+  { path: "/astra/getting-started/", title: /Getting Started|はじめる/ },
+  { path: "/astra/mount-on-mars/", title: /Mount on Mars|Mars にマウントする/ },
+  { path: "/astra/deploy/", title: /Deploy|デプロイ/ },
+  { path: "/search/" },
+  { path: "/ja/" },
+  { path: "/ja/astra/", title: /Astra/ },
+] as const;
+
+test.describe("Luna UI website deploy smoke", () => {
+  for (const page of PAGES) {
+    test(`page ${page.path} renders`, async ({ page: p }) => {
+      const res = await p.goto(page.path);
+      expect(res?.status(), `expected 2xx at ${page.path}`).toBe(200);
+      if (page.title) {
+        await expect(p).toHaveTitle(page.title);
+      }
+      // Every page must render at least one heading — empty body means CSS
+      // / Markdown pipeline blew up.
+      await expect(p.locator("h1, h2").first()).toBeVisible();
+    });
+  }
+
+  test("home loads inline CSS with theme variables", async ({ page }) => {
+    await page.goto("/");
+
+    // Astra inlines the design-system CSS (no external stylesheet for the
+    // base theme). If the inline <style> goes missing the variables vanish
+    // and the whole page renders unstyled.
+    const tokens = await page.evaluate(() => {
+      const style = getComputedStyle(document.documentElement);
+      return {
+        primary: style.getPropertyValue("--primary-color").trim(),
+        bg: style.getPropertyValue("--bg-color").trim(),
+        text: style.getPropertyValue("--text-color").trim(),
+        border: style.getPropertyValue("--border-color").trim(),
+      };
+    });
+    for (const [name, value] of Object.entries(tokens)) {
+      expect(value, `--${name}-color should resolve`).toMatch(
+        /^(#[0-9a-f]{3,8}|rgba?\(.+\))$/i,
+      );
+    }
+
+    // Theme bootstrap script flips `html` between light/dark on load. One
+    // of the two classes must end up on <html> — the absence of both means
+    // the inline script never ran.
+    const cls = await page.evaluate(() => document.documentElement.className);
+    expect(cls).toMatch(/(^|\s)(light|dark)(\s|$)/);
+  });
+
+  test("static assets are reachable", async ({ request }) => {
+    const assets = [
+      { path: "/assets/loader.js", contentType: /javascript/ },
+      { path: "/pagefind/pagefind.js", contentType: /javascript/ },
+      { path: "/pagefind/pagefind-ui.css", contentType: /css/ },
+    ];
+    for (const asset of assets) {
+      const res = await request.get(asset.path);
+      expect(res.status(), `${asset.path} should be 200`).toBe(200);
+      const ct = res.headers()["content-type"] ?? "";
+      expect(ct, `${asset.path} content-type`).toMatch(asset.contentType);
+    }
+  });
+
+  test("pagefind search UI mounts on /search/", async ({ page }) => {
+    await page.goto("/search/");
+    // The search page should render pagefind's container — either the
+    // form input or its wrapper. We don't drive a real search here, just
+    // confirm the asset graph hooked up.
+    const searchAffordance = page
+      .locator('[data-pagefind-ui], input[type="search"], #search')
+      .first();
+    await expect(searchAffordance).toBeVisible();
+  });
+
+  test("nav links to all four chapters from the home", async ({ page }) => {
+    await page.goto("/");
+    // Nav defined in website/sol.config.json: Luna, Sol, Astra, Search.
+    for (const target of ["/luna/", "/sol/", "/astra/", "/search/"]) {
+      const link = page.locator(`a[href="${target}"]`).first();
+      await expect(link, `home should link to ${target}`).toBeVisible();
+    }
+  });
+});

--- a/astra/e2e/playwright.config.mts
+++ b/astra/e2e/playwright.config.mts
@@ -32,6 +32,9 @@ const port = Number(process.env.ASTRA_E2E_PORT ?? 7780);
 
 export default defineConfig({
   testDir: ".",
+  // deployed/ targets the live website (luna.mizchi.workers.dev) via its
+  // own config and has no business hitting the localhost dev fixture.
+  testIgnore: ["**/deployed/**"],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/justfile
+++ b/justfile
@@ -85,8 +85,16 @@ test-e2e-ui:
     pnpm playwright test --config luna/e2e/playwright.config.mts --ui
 
 # luna-examples worker のデプロイ後 smoke (LUNA_EXAMPLES_URL で URL 上書き可)
-test-deployed:
+test-deployed-luna:
     pnpm playwright test --config luna/e2e/deployed/playwright.config.mts
+
+# Luna UI website のデプロイ後 smoke (WEBSITE_URL で URL 上書き可)
+# astra ローカル node_modules の playwright を使うため astra から実行
+test-deployed-website:
+    cd astra && pnpm exec playwright test --config e2e/deployed/playwright.config.mts
+
+# 全 deployed smoke (luna-examples + website)
+test-deployed: test-deployed-luna test-deployed-website
 
 # クロスプラットフォームテスト (js, wasm-gc, native)
 test-xplat:


### PR DESCRIPTION
## Summary

Mirror of #62, but for the astra-built website instead of the luna examples worker.

Adds 15 Playwright tests under \`astra/e2e/deployed/\` that hit the live deploy (default \`https://luna.mizchi.workers.dev\`, override \`WEBSITE_URL\` to point at the GitHub Pages mirror at \`https://mizchi.github.io/luna.mbt\` or any preview build).

Coverage:

- 11 routes resolve and render at least one heading: \`/\`, \`/introduction/overview/\`, \`/luna/\`, \`/sol/\`, \`/astra/\` (+ \`getting-started\`, \`mount-on-mars\`, \`deploy\`), \`/search/\`, \`/ja/\`, \`/ja/astra/\`
- Inline design-system CSS exposes \`--primary-color\` / \`--bg-color\` / \`--text-color\` / \`--border-color\` — catches a stripped \`<style>\` block (would fall through if astra ever loses its inline CSS bundling)
- Theme bootstrap puts \`light\` or \`dark\` on \`<html>\` on load
- \`/assets/loader.js\`, \`/pagefind/pagefind.js\`, \`/pagefind/pagefind-ui.css\` return 200 with correct content-type (regression for issue #50 / PR #58 — would have caught it)
- \`/search/\` mounts a pagefind affordance
- Home links to all four nav targets

\`testIgnore: ["**/deployed/**"]\` on the existing \`astra/e2e/playwright.config.mts\` keeps the localhost dev fixture from picking these up. Wired through:

- \`just test-deployed-website\` — astra only
- \`just test-deployed-luna\` — luna-examples only
- \`just test-deployed\` — both

Astra has its own \`@playwright/test\` pin (1.59.1) vs root's (1.58.2), so the website recipe runs \`pnpm exec playwright\` from \`astra/\` where the version resolves locally.

## Test plan
- [x] \`just test-deployed-website\` against \`luna.mizchi.workers.dev\` → 15/15 pass (1.8s)
- [ ] (optional) Run with \`WEBSITE_URL=https://mizchi.github.io/luna.mbt\` after a Pages deploy to validate the mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)