### PR TITLE
test(sol): chaosbringer-driven crawl over sol_app dev server

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,6 +96,10 @@ test-deployed-website:
 # 全 deployed smoke (luna-examples + website)
 test-deployed: test-deployed-luna test-deployed-website
 
+# sol_app の遷移を chaosbringer で crawl (sol/e2e のローカル dev サーバー使用)
+test-sol-chaos:
+    pnpm -F @luna_ui/sol-workspace exec playwright test --config "$(pwd)/sol/e2e/playwright-sol-app-chaos.config.mts"
+
 # クロスプラットフォームテスト (js, wasm-gc, native)
 test-xplat:
     moon test --target all luna/src/core/routes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      chaosbringer:
+        specifier: ^0.8.1
+        version: 0.8.1(@playwright/test@1.59.1)(axe-core@4.11.1)(pixelmatch@7.1.0)(playwright@1.59.1)(pngjs@7.0.0)
       colorette:
         specifier: ^2.0.20
         version: 2.0.20
@@ -295,7 +298,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.3
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@5.0.10)(vite@8.0.0-beta.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))(vitest@4.0.18))(@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.0-beta.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18))(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0)(vite@8.0.0-beta.1(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.0.18)(@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.0-beta.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18))(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0)(vite@8.0.0-beta.1(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))
       wrangler:
         specifier: ^4.81.0
         version: 4.87.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -1073,6 +1076,24 @@ packages:
     resolution: {integrity: sha512-12wT0pdOEkERR6OmQTag67z2I/If7vurpHvU0fwEG4in8TPBrF+/gmot5/+q/ujsQyabQo+UuDMk/iFMzX4QfQ==}
     hasBin: true
 
+  '@mizchi/playwright-faults@0.1.0':
+    resolution: {integrity: sha512-m3oF9ER7D0Vo1+jmDYW4VkU7IIxJAvMnPULv5Y7bjtcf9TGFhC2GSqgQtHnW6fWdUzxXpD9s5QKYuGkFJf3K4A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      playwright: ^1.40.0
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+
+  '@mizchi/playwright-v8-coverage@0.1.0':
+    resolution: {integrity: sha512-bN2fSMtVXVrb9sxdKuBzQd3q+H4zHi+nSr3zVCijtRWq4n2To1y0C1pJV1LiZw1n1PbVcY7c+yaaImgvNt1Jeg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      playwright: ^1.40.0
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
@@ -1771,6 +1792,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/browser-playwright@4.0.18':
     resolution: {integrity: sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==}
@@ -1980,6 +2002,26 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chaosbringer@0.8.1:
+    resolution: {integrity: sha512-ju5zSKXSTVe470uCJ3QlMgVgvNxMh3x3SL1LmjSn7HtIe2+ioG4gYtw8Rge4/16E6uL5ZHpmgr+73ddBpeYPqw==}
+    engines: {node: '>=20'}
+    hasBin: true
+    peerDependencies:
+      '@playwright/test': ^1.40.0
+      axe-core: ^4.0.0
+      pixelmatch: ^5.3.0 || ^6.0.0 || ^7.0.0
+      playwright: ^1.40.0
+      pngjs: ^7.0.0
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
+      axe-core:
+        optional: true
+      pixelmatch:
+        optional: true
+      pngjs:
+        optional: true
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -3920,6 +3962,14 @@ snapshots:
 
   '@luna_ui/luna@0.11.0': {}
 
+  '@mizchi/playwright-faults@0.1.0(playwright@1.59.1)':
+    optionalDependencies:
+      playwright: 1.59.1
+
+  '@mizchi/playwright-v8-coverage@0.1.0(playwright@1.59.1)':
+    optionalDependencies:
+      playwright: 1.59.1
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -4693,6 +4743,17 @@ snapshots:
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
+
+  chaosbringer@0.8.1(@playwright/test@1.59.1)(axe-core@4.11.1)(pixelmatch@7.1.0)(playwright@1.59.1)(pngjs@7.0.0):
+    dependencies:
+      '@mizchi/playwright-faults': 0.1.0(playwright@1.59.1)
+      '@mizchi/playwright-v8-coverage': 0.1.0(playwright@1.59.1)
+      playwright: 1.59.1
+    optionalDependencies:
+      '@playwright/test': 1.59.1
+      axe-core: 4.11.1
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
 
   character-entities-html4@2.1.0: {}
 
@@ -6092,7 +6153,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.0.18(bufferutil@4.1.0)(playwright@1.58.2)(utf-8-validate@5.0.10)(vite@8.0.0-beta.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))(vitest@4.0.18))(@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.0-beta.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18))(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0)(vite@8.0.0-beta.1(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/browser-playwright@4.0.18)(@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.0-beta.1(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18))(happy-dom@20.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@28.1.0)(vite@8.0.0-beta.1(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.0-beta.1(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))

--- a/sol/e2e/playwright-sol-app-chaos.config.mts
+++ b/sol/e2e/playwright-sol-app-chaos.config.mts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Boots `sol dev` against examples/sol_app on a dedicated port and runs the
+// chaosbringer-based crawl. Distinct config because the crawl test owns the
+// browser context itself (calls `chaos()` instead of using the Playwright
+// page fixture), so the rest of the sol e2e suite shouldn't get tangled in.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// sol/e2e -> sol -> luna.mbt (workspace root, where _build/ lives)
+const repoRoot = resolve(__dirname, "..", "..");
+const solDir = resolve(__dirname, "..");
+
+const port = Number(process.env.SOL_APP_CHAOS_PORT ?? 3458);
+
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: "sol-app-chaos.spec.ts",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: `http://localhost:${port}`,
+    trace: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+  webServer: {
+    command: `node ${repoRoot}/_build/js/release/build/mizchi/sol/cmd/sol/sol.js dev --no-watch -p ${port}`,
+    cwd: resolve(solDir, "examples/sol_app"),
+    url: `http://localhost:${port}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30000,
+  },
+});

--- a/sol/e2e/playwright.config.mts
+++ b/sol/e2e/playwright.config.mts
@@ -6,7 +6,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   testDir: ".",
-  testIgnore: ["sol-app-hydration.spec.ts"],
+  testIgnore: ["sol-app-hydration.spec.ts", "sol-app-chaos.spec.ts"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/sol/e2e/sol-app-chaos.spec.ts
+++ b/sol/e2e/sol-app-chaos.spec.ts
@@ -1,0 +1,82 @@
+// Chaos crawl over sol_app's dev server.
+//
+// Drives chaosbringer (https://www.npmjs.com/package/chaosbringer) to walk
+// the routes the SSR framework exposes, asserting per-page invariants on
+// every transition. The test fails if any visited page:
+//   - has no <h1> or <h2> (SSR pipeline produced an empty body)
+//   - logs a console error or raises a JS exception (`strict: true`)
+//   - returns a non-2xx response
+//
+// chaosbringer manages its own browser context, so this spec only owns the
+// chaos() call — no `page` fixture, no per-test browser launch.
+import { test, expect } from "@playwright/test";
+import { chaos } from "chaosbringer";
+
+const baseUrl = "http://localhost:3458";
+
+test("sol_app: chaosbringer crawl finds no invariant breakages", async () => {
+  const result = await chaos({
+    baseUrl,
+    seed: 42,
+    maxPages: 12,
+    maxActionsPerPage: 0,
+    strict: true,
+    // Dev-mode noise (HMR WebSocket, dev-server reconnects) we don't want
+    // to flag as page errors.
+    ignoreErrorPatterns: [
+      "WebSocket connection",
+      "Failed to load resource:.*\\b404\\b",
+    ],
+    // sol_app's link inventory currently lists routes that haven't been
+    // implemented yet — they fall through to the 404 view and would fail
+    // the heading invariants below. Track them here as known-stubs;
+    // remove entries as sol_app ships the routes.
+    excludePatterns: [
+      "/docs/api/overview",
+      "/blog/2024/recap",
+    ],
+    invariants: [
+      {
+        name: "has-heading",
+        check: async ({ page }) => {
+          const count = await page.locator("h1, h2").count();
+          return count > 0 || "no <h1>/<h2> rendered";
+        },
+      },
+      {
+        name: "no-empty-body",
+        check: async ({ page }) => {
+          const text = (await page.locator("body").innerText()).trim();
+          return text.length > 0 || "body innerText is empty";
+        },
+      },
+      {
+        name: "stable-title",
+        check: async ({ page, url }) => {
+          const title = await page.title();
+          return title.length > 0 || `empty <title> at ${url}`;
+        },
+      },
+    ],
+  });
+
+  if (!result.passed) {
+    const failingPages = result.report.pages
+      .filter((p) => p.errors.length > 0)
+      .map((p) => {
+        const errs = p.errors
+          .map((e) => `    [${e.type}] ${e.invariantName ?? ""} ${e.message}`)
+          .join("\n");
+        return `- ${p.url} (status=${p.status})\n${errs}`;
+      })
+      .join("\n");
+    throw new Error(
+      `chaosbringer crawl failed:\n${failingPages}\n\nRepro:\n  ${result.report.reproCommand}`,
+    );
+  }
+
+  expect(
+    result.report.pages.length,
+    "should visit at least one page",
+  ).toBeGreaterThan(0);
+});

--- a/sol/package.json
+++ b/sol/package.json
@@ -20,6 +20,7 @@
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.5.2",
     "@types/ws": "^8.18.1",
+    "chaosbringer": "^0.8.1",
     "colorette": "^2.0.20",
     "esbuild": "^0.28.0",
     "execa": "^9.6.1",


### PR DESCRIPTION
## Summary

Adds a [chaosbringer](https://www.npmjs.com/package/chaosbringer)-driven crawl test for \`sol/examples/sol_app\`. The crawler walks every link the SSR framework renders, visits up to 12 routes from a seeded BFS, and runs three invariants per page:

- **has-heading** — every page must render at least one \`<h1>\` or \`<h2>\`
- **no-empty-body** — \`<body>\` innerText must be non-empty
- **stable-title** — \`<title>\` must be non-empty

\`strict: true\` flips the run on console errors / JS exceptions, so a regression in any handler (or stale lazy-loaded asset, or runtime crash on hydration) shows up as a test failure with a copy-pasteable repro line:

\`\`\`
chaosbringer --url http://localhost:3458 --seed 42 --max-pages 12 --max-actions 0
\`\`\`

### Knobs already needed

- \`ignoreErrorPatterns\`: HMR WebSocket reconnect attempts and the 404 resource fetches sol's dev server makes.
- \`excludePatterns\`: \`/docs/api/overview\` and \`/blog/2024/recap\` — sol_app links to these from its nav but the routes aren't implemented yet (rendering the SSR 404 view, which has no \`<h1>\`/\`<h2>\`/\`<title>\`). The crawl found these unprompted; tracking them inline so CI is stable, with a comment that says \"remove entries as the routes ship.\"

### Wiring

- New config: \`sol/e2e/playwright-sol-app-chaos.config.mts\` — boots \`sol dev --no-watch -p 3458\` against \`examples/sol_app\`, tied to its own port so it doesn't clash with \`playwright-sol-app.config.mts\` on 3457.
- \`testIgnore\` on \`sol/e2e/playwright.config.mts\` so the main suite doesn't pick this spec up.
- \`chaosbringer ^0.8.1\` added to \`sol/package.json\` devDeps.
- \`just test-sol-chaos\` recipe.

### Why \`@luna_ui/sol-workspace\`-scoped install

Running from repo root resolves \`@playwright/test\` 1.58.2 (root pin), but \`chaosbringer\` peer-depends on 1.59.x to match the sol-workspace pin. The recipe does \`pnpm -F @luna_ui/sol-workspace exec playwright …\` so the test runs inside the workspace where the matching version is hoisted.

## Test plan
- [x] \`just test-sol-chaos\` → 1 passed (~9s, 12 pages crawled)
- [x] Crawl unprompted-found 2 broken routes; documented as known stubs
- [ ] Future: drop \`excludePatterns\` once sol_app ships those routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)