### PR TITLE
feat(sol): deploy sol_app to sol-examples.mizchi.workers.dev

### DIFF
--- a/.github/workflows/deploy-sol-examples.yml
+++ b/.github/workflows/deploy-sol-examples.yml
@@ -1,0 +1,56 @@
+name: deploy-sol-examples
+
+# Builds sol_app (Sol's flagship SSR example) into a Cloudflare Workers
+# bundle via `sol build` and deploys it to sol-examples.mizchi.workers.dev.
+# Other sol/examples/* are SSR-with-DB and aren't shipped from this worker.
+#
+# Trigger: same gating as deploy-website / deploy-luna-examples — fires on
+# sol-v* GitHub Releases (one deploy per release-please cycle).
+# workflow_dispatch is the manual fallback.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'sol-v') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - uses: hustcer/setup-moonbit@v1
+        with:
+          version: latest
+
+      - run: moon update
+
+      - run: pnpm install --frozen-lockfile
+
+      # `sol build` runs `moon build --target js --release` itself, but the
+      # workspace build also wires up loader / island chunks that downstream
+      # bundling depends on, so do it once up-front for parity with the
+      # other deploy workflows.
+      - run: moon build --target js --release
+
+      - name: sol build (sol_app)
+        working-directory: sol/examples/sol_app
+        run: node ${{ github.workspace }}/_build/js/release/build/mizchi/sol/cmd/sol/sol.js build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: sol/examples/sol_app
+          wranglerVersion: "4"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 !js/loader/dist/
 dist-docs/
 dist-demo/
+.sol/
 _build/
 
 # Wrangler / Cloudflare Workers

--- a/sol/examples/sol_app/.gitignore
+++ b/sol/examples/sol_app/.gitignore
@@ -6,6 +6,5 @@ app/__gen__
 app/client/__gen__*
 .sol
 package-lock.json
-wrangler.json
 zap-reports
 bench/results/*.json

--- a/sol/examples/sol_app/wrangler.json
+++ b/sol/examples/sol_app/wrangler.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../../node_modules/wrangler/config-schema.json",
+  "name": "sol-examples",
+  "main": ".sol/prod/server/main.js",
+  "compatibility_date": "2025-10-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": ".sol/prod/static",
+    "binding": "ASSETS"
+  },
+  "observability": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Summary

Mirrors the luna-examples deploy (#60) for Sol's flagship SSR example.

- `sol/examples/sol_app/wrangler.json` — entry `.sol/prod/server/main.js` (the bundle `sol build` produces from MoonBit), assets binding pointed at `.sol/prod/static/` for the client islands (`counter.js`, `wc_counter.js`, `contact_form.js`, `_shared/*`). Worker name: `sol-examples`.
- `.github/workflows/deploy-sol-examples.yml` — same gating shape as `deploy-website.yml` / `deploy-luna-examples.yml`: fires on `sol-v*` GitHub Releases (one deploy per release-please cycle) and `workflow_dispatch`. The job runs `moon build --target js --release`, then `sol build` inside `sol_app`, then `wrangler-action` from `sol/examples/sol_app/`.
- `.gitignore` — adds `.sol/` (sol's build cache) at repo root.
- `sol/examples/sol_app/.gitignore` — drops the `wrangler.json` exclusion so the deploy config can be checked in.

### Why only sol_app

- `sol_api`, `sol_auth`, `sol_sqlite`, `sol_todo` all assume a database the worker can't talk to — they're not Workers-deployable as-is.
- `ssg_test` is a docs site (sol's CLI even tells you to use astra for it).
- `sol_app` is the canonical "what Sol can do" example: SSR routing, multiple islands, server actions, navigation transitions.

### Verification

- `sol build` produces the expected entry + 5 client assets.
- `pnpm dlx wrangler@4 deploy --dry-run` reads `wrangler.json`, picks up the assets directory, and reports `Total Upload: 1911.60 KiB / gzip: 214.50 KiB` with a single `env.ASSETS` binding — no errors.

Note: branched into two commits because amend+force-push was blocked by auto-mode policy. The second commit is `feat(sol): add wrangler.json for sol_app`; squash-merge will collapse them.

## Test plan
- [x] `sol build` from `sol/examples/sol_app` produces `.sol/prod/server/main.js` + `.sol/prod/static/*`
- [x] `wrangler@4 deploy --dry-run` validates the bundle
- [ ] After merge: dispatch `deploy-sol-examples.yml` and verify `https://sol-examples.mizchi.workers.dev/` returns 200 with the home view
- [ ] Future: extend the smoke / chaosbringer crawl to also point at the deployed worker (or add a dedicated `deployed/` config under `sol/e2e/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)