### PR TITLE
fix(sol): patch eager seed init for Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy-sol-examples.yml
+++ b/.github/workflows/deploy-sol-examples.yml
@@ -47,6 +47,14 @@ jobs:
         working-directory: sol/examples/sol_app
         run: node ${{ github.workspace }}/_build/js/release/build/mizchi/sol/cmd/sol/sol.js build
 
+      # MoonBit core eagerly seeds hash randomization at module init via
+      # crypto.getRandomValues — Workers' global-scope I/O ban rejects the
+      # bundle (validation error 10021). Patch the built server.js to use a
+      # deterministic seed. See sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs.
+      - name: Patch Cloudflare global-scope I/O
+        working-directory: sol/examples/sol_app
+        run: node scripts/patch-cloudflare-globals.mjs
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:

--- a/sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs
+++ b/sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Cloudflare Workers disallow asynchronous I/O / random / timers in module
+// global scope. MoonBit core eagerly seeds the hash randomization state at
+// module init via `globalThis.crypto.getRandomValues`, which trips the
+// 10021 validation error and rejects the deploy.
+//
+// Patch the built server.js so the eager seed call becomes a deterministic
+// fallback (0). The seed is only used to randomize hash-table iteration
+// order at startup — a deterministic value preserves correctness, only
+// removes the DoS-resistance benefit of random hashing (acceptable for an
+// example deploy).
+//
+// Upstream fix would live in moonbitlang/core or sol's cloudflare adapter
+// (lazy-init the seed inside the first handler call). Until then this
+// post-build patch keeps sol_app deployable to Workers.
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverJsPath = resolve(
+  __dirname,
+  "..",
+  "_build",
+  "js",
+  "release",
+  "build",
+  "__gen__",
+  "server",
+  "server.js",
+);
+
+const original = readFileSync(serverJsPath, "utf8");
+
+const SEED_PATTERN = /const _M0FPB4seed = _M0FPB12random__seed\(\);/;
+
+if (!SEED_PATTERN.test(original)) {
+  throw new Error(
+    `patch-cloudflare-globals: \`const _M0FPB4seed = _M0FPB12random__seed();\` not found in ${serverJsPath}.\n` +
+      "MoonBit core may have changed the mangled symbol — update this script.",
+  );
+}
+
+const patched = original.replace(
+  SEED_PATTERN,
+  "const _M0FPB4seed = 0; /* patched by patch-cloudflare-globals.mjs: Workers disallow crypto in global scope */",
+);
+
+writeFileSync(serverJsPath, patched);
+console.log("patched _M0FPB4seed eager init -> 0 (Cloudflare Workers safe)");


### PR DESCRIPTION
## Summary

The first \`deploy-sol-examples\` run failed with Cloudflare validation error 10021:

\`\`\`
Disallowed operation called within global scope. Asynchronous I/O
(ex: fetch() or connect()), setting a timeout, and generating
random values are not allowed within global scope.
at _M0FPB12random__seed in __gen__/server/server.js:248
\`\`\`

Root cause: MoonBit core eagerly seeds the hash-randomization state at module init via \`globalThis.crypto.getRandomValues\`. Fine in Node / browsers, rejected by Workers, which forbids I/O in global scope.

Fix: post-build patch script that replaces the single eager call site:

\`\`\`js
const _M0FPB4seed = _M0FPB12random__seed();
\`\`\`

with:

\`\`\`js
const _M0FPB4seed = 0;
\`\`\`

Hash-table iteration order becomes deterministic; correctness is preserved (the seed only feeds DoS-resistance via hash randomization — fine for an example deploy where adversarial collisions aren't a threat).

Wired into \`deploy-sol-examples.yml\` between \`sol build\` and \`wrangler deploy\`. The script throws if the mangled symbol moves, so we'll notice MoonBit core changes in CI before they silently break things.

### Upstream fix

The proper fix lives in moonbitlang/core or sol's cloudflare adapter (lazy-init the seed inside the first handler call). Until that lands, this patch keeps sol_app deployable to Workers.

## Test plan
- [x] Local: \`sol build\` then \`patch-cloudflare-globals.mjs\` rewrites the seed init line; \`wrangler@4 deploy --dry-run\` validates the patched bundle
- [ ] After merge: dispatch \`deploy-sol-examples.yml\` and verify \`https://sol-examples.mizchi.workers.dev/\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)