### PR TITLE
fix(sol): stage __sol__/static dist-assets so islands hydrate

### DIFF
--- a/sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs
+++ b/sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs
@@ -36,17 +36,21 @@ const serverJsPath = resolve(
   let body = readFileSync(serverJsPath, "utf8");
 
   const SEED_PATTERN = /const _M0FPB4seed = _M0FPB12random__seed\(\);/;
-  if (!SEED_PATTERN.test(body)) {
+  const SEED_PATCHED = /const _M0FPB4seed = 0;/;
+  if (SEED_PATTERN.test(body)) {
+    body = body.replace(
+      SEED_PATTERN,
+      "const _M0FPB4seed = 0; /* patched: Workers disallow crypto in global scope */",
+    );
+    console.log("patched _M0FPB4seed eager init -> 0");
+  } else if (SEED_PATCHED.test(body)) {
+    console.log("_M0FPB4seed already patched, skipping");
+  } else {
     throw new Error(
-      `patch-cloudflare-globals: \`const _M0FPB4seed = _M0FPB12random__seed();\` not found in ${serverJsPath}.\n` +
+      `patch-cloudflare-globals: \`const _M0FPB4seed = ...\` not found in ${serverJsPath}.\n` +
         "MoonBit core may have changed the mangled symbol — update this script.",
     );
   }
-  body = body.replace(
-    SEED_PATTERN,
-    "const _M0FPB4seed = 0; /* patched: Workers disallow crypto in global scope */",
-  );
-  console.log("patched _M0FPB4seed eager init -> 0");
 
   // Sol's run_app picks mode 0 (sync export of __SOL_APP__) only when
   // is_adapter_mode && !runtime_is_node. On Workers with nodejs_compat,
@@ -56,18 +60,46 @@ const serverJsPath = resolve(
   // setInterval-poll to wait, but Workers ban timers in global scope.
   // Force mode 0 so __SOL_APP__ lands synchronously when server.js is imported.
   const MODE_PATTERN = /const mode = _p && !_p\$2 \? 0 : 1;/;
-  if (!MODE_PATTERN.test(body)) {
+  const MODE_PATCHED = /const mode = 0;/;
+  if (MODE_PATTERN.test(body)) {
+    body = body.replace(
+      MODE_PATTERN,
+      "const mode = 0; /* patched: force sync sol_app export on Cloudflare Workers */",
+    );
+    console.log("patched run_app mode -> 0 (sync export)");
+  } else if (MODE_PATCHED.test(body)) {
+    console.log("run_app mode already patched, skipping");
+  } else {
     throw new Error(
       `patch-cloudflare-globals: run_app mode selector not found in ${serverJsPath}.`,
     );
   }
-  body = body.replace(
-    MODE_PATTERN,
-    "const mode = 0; /* patched: force sync sol_app export on Cloudflare Workers */",
-  );
-  console.log("patched run_app mode -> 0 (sync export)");
 
   writeFileSync(serverJsPath, body);
+}
+
+// 1.5) Build the assets tree the Workers ASSETS binding will serve.
+//      `.sol/prod/__sol__/` (loader scripts) and `.sol/prod/static/` (island
+//      bundles) live as siblings under .sol/prod/. The binding maps a single
+//      directory to URL paths, so we materialize a dist-assets/ subtree that
+//      preserves the `__sol__/` and `static/` URL prefixes the SSR HTML
+//      references. Sibling `server/` is left out (it would expose worker
+//      source as a static asset).
+import { cpSync, rmSync, mkdirSync, existsSync } from "node:fs";
+{
+  const distAssets = resolve(sol_app, ".sol", "prod", "dist-assets");
+  rmSync(distAssets, { recursive: true, force: true });
+  mkdirSync(distAssets, { recursive: true });
+  const srcSol = resolve(sol_app, ".sol", "prod", "__sol__");
+  const srcStatic = resolve(sol_app, ".sol", "prod", "static");
+  if (!existsSync(srcSol) || !existsSync(srcStatic)) {
+    throw new Error(
+      `patch-cloudflare-globals: expected .sol/prod/__sol__ and .sol/prod/static to exist; run \`sol build\` first.`,
+    );
+  }
+  cpSync(srcSol, resolve(distAssets, "__sol__"), { recursive: true });
+  cpSync(srcStatic, resolve(distAssets, "static"), { recursive: true });
+  console.log("staged dist-assets/{__sol__,static}/ for ASSETS binding");
 }
 
 // 2) Sol's generated `.sol/prod/server/main.js` polls `globalThis.__SOL_APP__`
@@ -81,21 +113,25 @@ const mainJsPath = resolve(sol_app, ".sol", "prod", "server", "main.js");
   const original = readFileSync(mainJsPath, "utf8");
   const POLL_PATTERN =
     /const app = await new Promise\(resolve => \{[\s\S]*?\}\);/;
-  if (!POLL_PATTERN.test(original)) {
+  const POLL_PATCHED = /const app = globalThis\.__SOL_APP__;/;
+  if (POLL_PATTERN.test(original)) {
+    const patched = original.replace(
+      POLL_PATTERN,
+      [
+        "const app = globalThis.__SOL_APP__;",
+        "/* patched by patch-cloudflare-globals.mjs: Cloudflare sets __SOL_APP__",
+        "   synchronously on import, no setInterval needed (and Workers ban",
+        "   timers in global scope anyway). */",
+      ].join("\n"),
+    );
+    writeFileSync(mainJsPath, patched);
+    console.log("patched main.js __SOL_APP__ poll -> sync access");
+  } else if (POLL_PATCHED.test(original)) {
+    console.log("main.js __SOL_APP__ poll already patched, skipping");
+  } else {
     throw new Error(
       `patch-cloudflare-globals: setInterval poll block not found in ${mainJsPath}.\n` +
         "Sol's main.js template may have changed — update this script.",
     );
   }
-  const patched = original.replace(
-    POLL_PATTERN,
-    [
-      "const app = globalThis.__SOL_APP__;",
-      "/* patched by patch-cloudflare-globals.mjs: Cloudflare sets __SOL_APP__",
-      "   synchronously on import, no setInterval needed (and Workers ban",
-      "   timers in global scope anyway). */",
-    ].join("\n"),
-  );
-  writeFileSync(mainJsPath, patched);
-  console.log("patched main.js __SOL_APP__ poll -> sync access");
 }

--- a/sol/examples/sol_app/wrangler.json
+++ b/sol/examples/sol_app/wrangler.json
@@ -5,7 +5,7 @@
   "compatibility_date": "2025-10-01",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "directory": ".sol/prod/static",
+    "directory": ".sol/prod/dist-assets",
     "binding": "ASSETS"
   },
   "observability": {


### PR DESCRIPTION
Counter on / didn't increment — SSR HTML loaded fine but every island/loader URL responded with the worker's "Not found" stub. Wrangler's ASSETS binding maps the configured `directory` to URL paths verbatim, so `directory: .sol/prod/static` exposed `/counter.js` (not `/static/counter.js`) and missed `/__sol__/` entirely. Patch script now stages a `.sol/prod/dist-assets/` tree mirroring the URL layout (`__sol__/*` + `static/*`); wrangler.json points at it. Patches are now idempotent.