### PR TITLE
docs: project skills for sol cloudflare deploy + playwright skew

### DIFF
--- a/.claude/skills/playwright-pnpm-workspace/SKILL.md
+++ b/.claude/skills/playwright-pnpm-workspace/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: playwright-pnpm-workspace
+description: Use when running Playwright tests in this repo (luna.mbt) and either the test fails to discover specs ("did not expect test.describe()" / "two different versions of @playwright/test") or you're adding a new playwright config under astra/ or sol/. Captures the version-skew between root and per-package @playwright/test pins.
+---
+
+# playwright-pnpm-workspace
+
+## Purpose
+
+luna.mbt root pins `@playwright/test@^1.58.2`, but `astra/package.json` and `sol/package.json` independently pin `^1.59.1`. Running `pnpm exec playwright` from the repo root resolves the older root-level version, while spec files imported from `astra/e2e/` or `sol/e2e/` resolve the newer per-package one. Playwright crashes with "did not expect test.describe()" because the registered test type and the discovered file disagree on which copy of `@playwright/test` they're holding.
+
+This skill records which command to use for which directory and avoids burning a CI cycle on a version-skew bug.
+
+## When to use
+
+- Adding or running a playwright config under `astra/e2e/` or `sol/e2e/`
+- Seeing `Playwright Test did not expect test.describe() to be called here` at test discovery
+- Adjusting `@playwright/test` versions across the monorepo
+- Wiring a new `just test-…` recipe that drives playwright
+
+## Workflow
+
+### Pick the runner based on where the spec lives
+
+| Specs in | Use this command | Why |
+|---|---|---|
+| `luna/e2e/**` | `pnpm exec playwright …` (from repo root) | `luna/` is not a separate workspace package; tests resolve through root's `@playwright/test@1.58.2`. |
+| `astra/e2e/**` | `cd astra && pnpm exec playwright …` *or* `pnpm -F @mizchi/astra-e2e exec playwright …` | `astra/package.json` pins 1.59.1; root's 1.58.2 will crash. |
+| `sol/e2e/**` | `pnpm -F @luna_ui/sol-workspace exec playwright …` | `sol/package.json` pins 1.59.1 too. `cd sol` is unreliable here because zsh redirects `sol` to a sibling repo via `hash -d`. |
+
+Wired examples in `justfile`:
+
+```just
+test-deployed-luna:
+    pnpm playwright test --config luna/e2e/deployed/playwright.config.mts
+
+test-deployed-website:
+    cd astra && pnpm exec playwright test --config e2e/deployed/playwright.config.mts
+
+test-sol-chaos:
+    pnpm -F @luna_ui/sol-workspace exec playwright test --config "$(pwd)/sol/e2e/playwright-sol-app-chaos.config.mts"
+```
+
+The `$(pwd)/...` absolute path on `test-sol-chaos` is intentional — `pnpm -F` runs in the workspace's own cwd, so a relative config path would resolve wrong.
+
+### Adding a new playwright config
+
+1. Decide which package owns the spec (root / astra / sol). The package that owns it sets which `@playwright/test` version applies.
+2. If the new config lives under an existing playwright config's `testDir`, add the new path to the existing config's `testIgnore` so the original suite doesn't accidentally pick it up.
+3. Add a `just test-…` recipe matching the runner table above.
+4. Run locally before pushing. CI cycles on this kind of bug are expensive (only luna-e2e fails, the rest pass — easy to misdiagnose).
+
+### Symptoms of skew
+
+- `Playwright Test did not expect test.describe() to be called here` — you're running with the wrong `@playwright/test` for the test file.
+- `Error: No tests found` after the above — same root cause; playwright bailed before discovery completed.
+- A test suite under `astra/e2e/deployed/` *passes locally* but the `luna-e2e` CI job fails referencing the same file — the localhost playwright config is also picking up the deployed/ specs because of glob-greedy `testMatch`. Add `testIgnore: ["**/deployed/**"]`.
+
+## Pitfalls
+
+- **`cd sol`** in zsh on this machine redirects to `~/ghq/github.com/mizchi/sol.mbt` (a sibling repo), not `luna.mbt/sol/`. Use `pnpm -F` instead, or absolute paths.
+- **`testMatch` is rooted at `testDir`** but `**` globs cross subdirectories. A new sibling dir under an existing `testDir` will be picked up unless explicitly ignored.
+- **Don't unify versions casually.** Bumping root to 1.59.1 looks tempting, but `vitest-browser` (root devDep) currently pulls in `@vitest/browser-playwright@4.0.18` which has its own playwright peer constraint. Check the unmet-peer warnings before dragging the root version forward.
+- **`pnpm -F` runs in the package's cwd.** Relative `--config` paths won't resolve as you expect when the package is nested. Pass an absolute path (`$(pwd)/sol/e2e/...`) or `cd` into the package first.
+
+## Related
+
+- `luna/e2e/playwright.config.mts`, `astra/e2e/playwright.config.mts`, `sol/e2e/playwright.config.mts` — the three roots; each ignores `**/deployed/**` (and luna's also ignores `**/visual-snapshots.test.ts` in CI).
+- `justfile` — the canonical recipes.

--- a/.claude/skills/sol-cloudflare-deploy/SKILL.md
+++ b/.claude/skills/sol-cloudflare-deploy/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: sol-cloudflare-deploy
+description: Use when deploying sol_app (or any sol-built MoonBit SSR worker) to Cloudflare Workers, debugging error 10021, or extending sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs. Captures the global-scope I/O traps in MoonBit core + sol's generated bundle and the wrangler ASSETS binding URL layout.
+---
+
+# sol-cloudflare-deploy
+
+## Purpose
+
+Deploying `sol/examples/sol_app` (or another sol-generated SSR bundle) to Cloudflare Workers triggers three independent global-scope I/O violations and one ASSETS binding URL mismatch. Each one only surfaces *after* the previous one is fixed, so naive iteration burns one deploy cycle per trap. This skill bundles the full checklist so a future deploy goes through in one pass.
+
+Concrete artifact: `sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs`. Keep that file in sync with the rules below.
+
+## When to use
+
+- Adding a new sol example to a Cloudflare Workers deploy
+- Bumping the MoonBit toolchain or `mizchi/sol` version (the mangled symbols in the patch script can drift)
+- Debugging a fresh `error 10021` (`Disallowed operation called within global scope`)
+- Auditing a Workers-bound bundle for top-level I/O before the first deploy
+
+## Workflow
+
+### 0. Always dry-run first
+
+```sh
+pnpm dlx wrangler@4 deploy --dry-run
+```
+
+Run this from `sol/examples/sol_app/` after `sol build` + the patch script. Validation error 10021 is detected in dry-run, not just on the live API call. **One deploy cycle per silent fix is wasteful — surface every violation locally first.**
+
+### 1. Three global-scope I/O traps to patch
+
+The post-build patch script rewrites three call sites. Re-run it after every `sol build` (or wire it into the deploy workflow between `sol build` and `wrangler deploy`).
+
+| # | File | Symptom | Patch |
+|---|------|---------|-------|
+| 1 | `_build/.../__gen__/server/server.js` | `_M0FPB12random__seed()` called at module top-level via `globalThis.crypto.getRandomValues`. MoonBit core's eager hash-randomization seed. | `const _M0FPB4seed = _M0FPB12random__seed();` → `const _M0FPB4seed = 0;` |
+| 2 | `_build/.../__gen__/server/server.js` | `run_app` mode selector picks the async `with_initialized_fs` branch on Workers (because `process.versions.node` is populated under `nodejs_compat`), which awaits `import('node:fs')` at module load. | `const mode = _p && !_p$2 ? 0 : 1;` → `const mode = 0;` (force sync export) |
+| 3 | `.sol/prod/server/main.js` | `await new Promise(resolve => { ... setInterval(...) ... })` polls for `globalThis.__SOL_APP__` at top level. Workers ban timers in global scope. | Whole block → `const app = globalThis.__SOL_APP__;` (sync access — works once trap #2 is fixed) |
+
+The script must stay **idempotent**: re-running after a partial-applied state shouldn't crash. Each rewrite checks both pre- and post-patched patterns and skips if already done.
+
+If MoonBit core / sol changes mangled symbols, the patch script's regex pattern won't match. The script is intentionally strict (throws when the pattern is missing) so a silently-changed upstream is loud, not silent.
+
+### 2. wrangler ASSETS binding maps `directory` verbatim
+
+`wrangler.json`:
+
+```jsonc
+{
+  "assets": {
+    "directory": ".sol/prod/dist-assets",
+    "binding": "ASSETS"
+  }
+}
+```
+
+The HTML sol generates references `/static/<island>.js` and `/__sol__/<loader>.js`. wrangler's ASSETS binding maps the configured `directory` *root* to `/`, so:
+
+- `directory: ".sol/prod/static"` → `/__sol__/*` and `/static/*` are both 404 (the `__sol__/` siblings aren't even seen, and `static/counter.js` ends up at `/counter.js`, not `/static/counter.js`).
+- Need: a `dist-assets/` tree mirroring the URL layout (`__sol__/*` + `static/*`). The patch script stages this from `.sol/prod/__sol__/` and `.sol/prod/static/`. The sibling `.sol/prod/server/` stays excluded — exposing it would leak server source.
+
+When adding new asset prefixes (e.g. `/admin/static/...`), update both the patch script's copy step and any sol-side URL emission.
+
+### 3. Initial deploy must not poison browser caches
+
+The first broken deploy will return worker fallback responses (e.g. `// Not found: loader.js`). Cloudflare's Workers Static Assets default `cache-control` for ASSETS routes that fall through to the worker can be longer than expected — and clients that loaded the broken state cache it for the full TTL.
+
+Two safeguards:
+
+- **wrangler default for assets is currently `max-age=0, must-revalidate`**. Verify with `curl -sI https://sol-examples.mizchi.workers.dev/__sol__/loader.js` after deploy that the header reads `cache-control: public, max-age=0, must-revalidate`. If it ever drifts (custom worker handler, wrangler upgrade), re-pin in `wrangler.json` via `assets.headers` or a worker-side `Response` header.
+- **Symptom of the trap**: deploy goes green, but a previously-loaded session stays broken because the script tag still resolves to a stale stub from disk cache. Clear with hard reload (Cmd+Shift+R) or new incognito; instruct users likewise. Don't waste a debug cycle re-deploying when the edge already serves correct bytes — verify with `curl` first.
+
+Long-term upstream fix: sol should emit versioned script src (`/__sol__/loader.js?v=<deploy-hash>`) so URL changes per deploy. Until that lands, breaking the cache requires a URL change.
+
+### 4. Verify with all three layers
+
+After `wrangler deploy` reports success:
+
+```sh
+# Edge content
+curl -s https://sol-examples.mizchi.workers.dev/__sol__/loader.js | wc -c   # ~5700 bytes
+curl -s https://sol-examples.mizchi.workers.dev/static/counter.js | head -c 40
+curl -sI https://sol-examples.mizchi.workers.dev/__sol__/loader.js | grep -i cache-control
+
+# Server-rendered HTML
+curl -s https://sol-examples.mizchi.workers.dev/ | grep -oE '<title>[^<]*</title>'
+
+# Hydration (browser only): visit in incognito, click +/- on the homepage counter, value should change.
+```
+
+If hydration fails but edge serves the right bytes, suspect browser cache from an earlier broken deploy. Don't redeploy — hard reload first.
+
+## Pitfalls
+
+- **One trap at a time hides the others.** Each global-I/O fix unblocks the next bundle import, and the next violation only fires once the previous is patched. Always run the patch script in full + `wrangler deploy --dry-run` rather than ship-and-pray.
+- **Patch script not idempotent → CI re-runs explode.** Both pre- and post-patched regex must be checked; idempotency is part of the contract.
+- **Mangled symbol drift.** `_M0FPB4seed` / `_M0FPB12random__seed` etc are MoonBit core mangled names. They'll change across MoonBit toolchain bumps. The script throws if the pattern is missing — investigate and update, don't just relax the regex.
+- **`directory: ".sol/prod"` exposes server source.** Don't be tempted to point ASSETS at `.sol/prod/` directly to "include everything"; `.sol/prod/server/main.js` would become a public asset.
+- **`nodejs_compat` is necessary** in `compatibility_flags` because sol's bundle uses `process` and `node:fs` symbols. But it also makes `process.versions.node` truthy, which is exactly what makes sol's `runtime_is_node` mis-detect Workers — this is *why* trap #2 exists.
+- **Don't re-deploy to "fix" a stale browser cache.** The edge is already correct; only the client needs to refresh.
+- **Cache poison from initial broken deploy lasts for the asset's `cache-control` TTL.** If an early deploy ever emitted `max-age=3600` (older wrangler defaults / explicit override), that's how long affected sessions stay broken. The current default of `max-age=0, must-revalidate` makes this self-healing for fresh visitors.
+
+## Related
+
+- `sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs` — the concrete artifact this skill describes
+- `.github/workflows/deploy-sol-examples.yml` — wires `moon build` → `sol build` → patch → `wrangler deploy`
+- `sol/CHANGELOG.md` — once upstream sol gets a Workers-aware adapter, this skill (and the patch script) can shrink

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tmp/
 
 # TypeScript build info
 *.tsbuildinfo
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Codifies the lessons from this session as project-scoped skills under `.claude/skills/`, plus a small `.gitignore` entry.

### Skills added

- **`sol-cloudflare-deploy`** — MoonBit + sol bundle hits three independent module-top-level I/O traps on Cloudflare Workers (random seed, setInterval poll, run_app fs init), each only surfacing after the previous fix. Captures the full checklist plus wrangler ASSETS binding URL layout (mirror `__sol__/` + `static/` under a `dist-assets/` tree, never expose `server/`) and the broken-deploy cache-poisoning angle (`max-age=3600` from an early bad deploy can stick to a session for an hour). Cross-references `sol/examples/sol_app/scripts/patch-cloudflare-globals.mjs`.
- **`playwright-pnpm-workspace`** — root pins `@playwright/test@1.58.2`, `astra/` and `sol/` pin `1.59.1`. Running `pnpm exec playwright` from the wrong cwd crashes with "Playwright Test did not expect test.describe()". The skill is the runner table: which `pnpm -F` / `cd` to use per spec location, plus the gotcha that `cd sol` in zsh on this machine redirects to a sibling repo via `hash -d`.

### `.gitignore`

Adds `.claude/scheduled_tasks.lock` (per-machine state from the schedule skill).

### Why project-scoped

Both lessons are tightly coupled to this repo's specifics — the patch script's mangled MoonBit symbols, the per-package playwright pins, the just recipes. A global skill would be either too vague to be useful or accidentally apply to unrelated repos. Living under `<repo>/.claude/skills/` lets `apm.yml` (or just colocation) keep them next to the code they describe.

## Test plan
- [x] `Skill` tool can find both by name (project skills ride directly off the filesystem)
- [ ] Future agent run of "deploy sol_app" should pick up `sol-cloudflare-deploy` and skip the trap-by-trap iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)