### PR TITLE
fix(luna): add missing `wc` field to ComponentRef struct

### DIFF
--- a/luna/src/core/vnode.mbt
+++ b/luna/src/core/vnode.mbt
@@ -155,10 +155,12 @@ pub type Trigger = TriggerType
 /// Represents a client-side Web Components Island that can be embedded in server-rendered HTML
 /// - url: Path to the client JavaScript (e.g., "/static/counter.js")
 /// - props: Component props (must be ToJson serializable)
+/// - wc: Whether this references a Web Component island
 /// - trigger: When to hydrate the component
 pub(all) struct ComponentRef[T] {
   url : String
   props : T
+  wc : Bool
   trigger : TriggerType
 }
 

--- a/luna/src/core/vnode_builders.mbt
+++ b/luna/src/core/vnode_builders.mbt
@@ -264,7 +264,7 @@ pub fn[T] component_ref(
   props : T,
   trigger? : TriggerType = Load,
 ) -> ComponentRef[T] {
-  { url, props, trigger }
+  { url, props, wc: false, trigger }
 }
 
 ///|
@@ -274,7 +274,7 @@ pub fn[T] wc_component_ref(
   props : T,
   trigger? : TriggerType = Load,
 ) -> ComponentRef[T] {
-  { url, props, trigger }
+  { url, props, wc: true, trigger }
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

Add the missing `wc : Bool` field to `@luna/core.ComponentRef[T]` so the struct source matches its already-published `.mbti` and sol's codegen.

Fixes #92.

## Why

The interface `luna/src/core/pkg.generated.mbti` and sol's generator `sol/src/cli/type_generator.mbt:81` both expect `ComponentRef[T]` to carry a `wc` field, but the struct source (`luna/src/core/vnode.mbt`) declared only `url` / `props` / `trigger`. A freshly scaffolded `sol new` project therefore failed to build:

```
Error: [4091]
   { url, props, wc: false, trigger }
                 ─┬
                  ╰── The fields wc is not defined in the record type
                      @mizchi/luna/core.ComponentRef[CounterProps].
```

No published luna version contained `wc` in the struct, so the scaffold had no working sol/luna pairing out of the box.

## Changes

- `luna/src/core/vnode.mbt`: add `wc : Bool` to `struct ComponentRef[T]` (+ doc line).
- `luna/src/core/vnode_builders.mbt`: set the field in both builders — `component_ref` → `wc: false`, `wc_component_ref` → `wc: true`.

`pkg.generated.mbti` already declared `wc`, so it needs no change.

## Verification

- `moon check --target js` — 0 errors (398 tasks).
- `moon test --target js` — total **2810** tests; the only failures are pre-existing and unrelated to this change (`mizchi/sol` version-pin fixtures expecting `0.22.x` while the tree is at `0.23.0`, and memfs node-module resolution when `node_modules` is absent). None touch `ComponentRef`.
- End-to-end: applied the same patch to a scaffolded `sol new` app; `sol build` + `sol serve` then succeed and SSR renders the counter / api_tools islands correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
