### PR TITLE
perf(luna): optimize SSR escaping

### DIFF
--- a/luna/src/core/render/escape.mbt
+++ b/luna/src/core/render/escape.mbt
@@ -13,14 +13,50 @@ pub fn needs_html_escape(s : String) -> Bool {
 ///|
 /// Escape HTML special characters and write to StringBuilder
 pub fn escape_html_to(sb : StringBuilder, s : String) -> Unit {
-  for c in s {
-    match c {
-      '&' => sb.write_string("&amp;")
-      '<' => sb.write_string("&lt;")
-      '>' => sb.write_string("&gt;")
-      '"' => sb.write_string("&quot;")
-      '\'' => sb.write_string("&#39;")
-      _ => sb.write_char(c)
+  escape_html_view_to(sb, s[:])
+}
+
+///|
+fn escape_html_view_to(sb : StringBuilder, s : StringView) -> Unit {
+  let len = s.length()
+  fn flush_segment(start : Int, end : Int) -> Unit {
+    if end > start {
+      sb.write_view(s[start:end])
+    }
+  }
+
+  for i = 0, segment_start = 0 {
+    if i >= len {
+      flush_segment(segment_start, i)
+      break
+    }
+    match s.unsafe_get(i) {
+      '&' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&amp;")
+        continue i + 1, i + 1
+      }
+      '<' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&lt;")
+        continue i + 1, i + 1
+      }
+      '>' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&gt;")
+        continue i + 1, i + 1
+      }
+      '"' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&quot;")
+        continue i + 1, i + 1
+      }
+      '\'' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&#39;")
+        continue i + 1, i + 1
+      }
+      _ => continue i + 1, segment_start
     }
   }
 }
@@ -45,11 +81,35 @@ pub fn needs_attr_escape(s : String) -> Bool {
 ///|
 /// Escape attribute value and write to StringBuilder
 pub fn escape_attr_to(sb : StringBuilder, s : String) -> Unit {
-  for c in s {
-    match c {
-      '&' => sb.write_string("&amp;")
-      '"' => sb.write_string("&quot;")
-      _ => sb.write_char(c)
+  escape_attr_view_to(sb, s[:])
+}
+
+///|
+fn escape_attr_view_to(sb : StringBuilder, s : StringView) -> Unit {
+  let len = s.length()
+  fn flush_segment(start : Int, end : Int) -> Unit {
+    if end > start {
+      sb.write_view(s[start:end])
+    }
+  }
+
+  for i = 0, segment_start = 0 {
+    if i >= len {
+      flush_segment(segment_start, i)
+      break
+    }
+    match s.unsafe_get(i) {
+      '&' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&amp;")
+        continue i + 1, i + 1
+      }
+      '"' => {
+        flush_segment(segment_start, i)
+        sb.write_string("&quot;")
+        continue i + 1, i + 1
+      }
+      _ => continue i + 1, segment_start
     }
   }
 }

--- a/luna/src/core/render/pkg.generated.mbti
+++ b/luna/src/core/render/pkg.generated.mbti
@@ -34,9 +34,9 @@ pub fn render_attr_value(StringBuilder, String, String) -> Unit
 
 pub fn[E, A : Show] render_attrs_to(StringBuilder, Array[(String, @core.Attr[E, A])]) -> Unit
 
-pub fn[E, A : Show] render_to_string(@core.Node[E, A], preload? : Bool) -> SSRResult
+pub fn[E, A : Show] render_to_string(@core.Node[E, A], preload? : Bool, size_hint? : Int) -> SSRResult
 
-pub fn[E, A : Show] render_to_string_with_hydration(@core.Node[E, A]) -> String
+pub fn[E, A : Show] render_to_string_with_hydration(@core.Node[E, A], size_hint? : Int) -> String
 
 // Errors
 

--- a/luna/src/core/render/render_test.mbt
+++ b/luna/src/core/render/render_test.mbt
@@ -77,6 +77,20 @@ test "render_to_string text node" {
 }
 
 ///|
+test "render_to_string accepts size hint" {
+  let node : @core.Node[Unit, String] = @core.text("Hello")
+  let result = render_to_string(node, size_hint=1024)
+  assert_eq(result.html, "Hello")
+}
+
+///|
+test "render_to_string_with_hydration accepts size hint" {
+  let node : @core.Node[Unit, String] = @core.text_dyn(fn() { "Hello" })
+  let html = render_to_string_with_hydration(node, size_hint=1024)
+  assert_eq(html, "<!--t:0-->Hello<!--/t-->")
+}
+
+///|
 test "render_to_string element" {
   let node : @core.Node[Unit, String] = @core.h("div", [], [
     @core.text("content"),
@@ -88,11 +102,11 @@ test "render_to_string element" {
 ///|
 test "render_to_string reverse pipeline element" {
   let node : @core.Node[Unit, String] = @core.h("div", []) <| [
-      @core.text("hello"),
-      @core.h("span", []) <| [
-        @core.text("world"),
-      ],
-    ]
+    @core.text("hello"),
+    @core.h("span", []) <| [
+      @core.text("world"),
+    ],
+  ]
   let result = render_to_string(node)
   assert_eq(result.html, "<div>hello<span>world</span></div>")
 }
@@ -113,6 +127,17 @@ test "render_to_string with static attr" {
   )
   let result = render_to_string(node)
   assert_eq(result.html, "<div class=\"container\"></div>")
+}
+
+///|
+test "render_to_string skips remove marker attr" {
+  let node : @core.Node[Unit, String] = @core.h(
+    "div",
+    [("hidden", @core.attr_static("__remove__"))],
+    [],
+  )
+  let result = render_to_string(node)
+  assert_eq(result.html, "<div></div>")
 }
 
 ///|

--- a/luna/src/core/render/render_to_string.mbt
+++ b/luna/src/core/render/render_to_string.mbt
@@ -15,8 +15,9 @@ pub struct SSRResult {
 pub fn[E, A : Show] render_to_string(
   node : @core.Node[E, A],
   preload? : Bool = false,
+  size_hint? : Int = 256,
 ) -> SSRResult {
-  let sb = StringBuilder::new(size_hint=256)
+  let sb = StringBuilder::new(size_hint~)
   if preload {
     let urls : Array[String] = []
     let seen : Map[String, Bool] = {}
@@ -577,8 +578,9 @@ fn[E, A : Show] render_to_sb(
 /// Render with data-ssr-id markers for hydration
 pub fn[E, A : Show] render_to_string_with_hydration(
   node : @core.Node[E, A],
+  size_hint? : Int = 256,
 ) -> String {
-  let sb = StringBuilder::new(size_hint=256)
+  let sb = StringBuilder::new(size_hint~)
   let id_counter = Ref(0)
   let island_ids = new_island_id_allocator()
   render_with_id_to(sb, node, id_counter, island_ids)

--- a/luna/src/core/serialize/json.mbt
+++ b/luna/src/core/serialize/json.mbt
@@ -71,20 +71,59 @@ fn write_double(f : Double, buf : StringBuilder) -> Unit {
 ///|
 /// Escape special characters in JSON string
 fn write_escaped_string(s : String, buf : StringBuilder) -> Unit {
-  for char in s {
+  write_escaped_string_view(s[:], buf)
+}
+
+///|
+fn write_escaped_string_view(s : StringView, buf : StringBuilder) -> Unit {
+  let len = s.length()
+  fn flush_segment(start : Int, end : Int) -> Unit {
+    if end > start {
+      buf.write_view(s[start:end])
+    }
+  }
+
+  for i = 0, segment_start = 0 {
+    if i >= len {
+      flush_segment(segment_start, i)
+      break
+    }
+    let char = s.unsafe_get(i)
     match char {
-      '"' => buf.write_string("\\\"")
-      '\\' => buf.write_string("\\\\")
-      '\n' => buf.write_string("\\n")
-      '\r' => buf.write_string("\\r")
-      '\t' => buf.write_string("\\t")
+      '"' => {
+        flush_segment(segment_start, i)
+        buf.write_string("\\\"")
+        continue i + 1, i + 1
+      }
+      '\\' => {
+        flush_segment(segment_start, i)
+        buf.write_string("\\\\")
+        continue i + 1, i + 1
+      }
+      '\n' => {
+        flush_segment(segment_start, i)
+        buf.write_string("\\n")
+        continue i + 1, i + 1
+      }
+      '\r' => {
+        flush_segment(segment_start, i)
+        buf.write_string("\\r")
+        continue i + 1, i + 1
+      }
+      '\t' => {
+        flush_segment(segment_start, i)
+        buf.write_string("\\t")
+        continue i + 1, i + 1
+      }
       _ =>
         if char.to_int() < 32 {
           // Control characters
+          flush_segment(segment_start, i)
           buf.write_string("\\u")
           write_hex4(char.to_int(), buf)
+          continue i + 1, i + 1
         } else {
-          buf.write_char(char)
+          continue i + 1, segment_start
         }
     }
   }


### PR DESCRIPTION
## Summary
- chunk-write HTML, attribute, and JSON string escaping via StringView slices
- add optional SSR size_hint parameters for render_to_string and render_to_string_with_hydration
- keep attr Show/to_string path after direct logger attempt regressed render benchmarks

## Validation
- just check
- just test-moonbit: 2819 passed
- just test-vitest: 705 passed
- just test-e2e: 168 passed
- just moonbench-check
- just treeshake-size: unchanged client treeshake sizes, render remains 7025 B / 2263 B
- just bundle-size: unchanged loader bundle sizes