### PR TITLE
test(luna): add stream render moonbench coverage

### DIFF
--- a/luna/scripts/moonbench-baseline.json
+++ b/luna/scripts/moonbench-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T13:35:59.200Z",
+  "generatedAt": "2026-07-07T16:19:08.116Z",
   "node": "v24.12.0",
   "platform": "darwin",
   "arch": "arm64",
@@ -9,25 +9,43 @@
       "id": "core/render/render: large_list (100 items with escape)",
       "suite": "core/render",
       "name": "render: large_list (100 items with escape)",
-      "nsPerOp": 76390
+      "nsPerOp": 22345
     },
     {
       "id": "core/render/render: list (10 items)",
       "suite": "core/render",
       "name": "render: list (10 items)",
-      "nsPerOp": 2870
+      "nsPerOp": 887.94
     },
     {
       "id": "core/render/render: page",
       "suite": "core/render",
       "name": "render: page",
-      "nsPerOp": 2480
+      "nsPerOp": 836.86
     },
     {
       "id": "core/serialize/state_value_to_json: large_array",
       "suite": "core/serialize",
       "name": "state_value_to_json: large_array",
-      "nsPerOp": 3280
+      "nsPerOp": 1585
+    },
+    {
+      "id": "core/stream_render/stream render: large_list (100 items with escape)",
+      "suite": "core/stream_render",
+      "name": "stream render: large_list (100 items with escape)",
+      "nsPerOp": 25540
+    },
+    {
+      "id": "core/stream_render/stream render: list (10 items)",
+      "suite": "core/stream_render",
+      "name": "stream render: list (10 items)",
+      "nsPerOp": 995.75
+    },
+    {
+      "id": "core/stream_render/stream render: page",
+      "suite": "core/stream_render",
+      "name": "stream render: page",
+      "nsPerOp": 991.97
     }
   ]
 }

--- a/luna/scripts/moonbench-check.mjs
+++ b/luna/scripts/moonbench-check.mjs
@@ -53,6 +53,26 @@ const SUITES = [
       "state_value_to_json: large_array",
     ]),
   },
+  {
+    id: "core/stream_render",
+    cmd: [
+      "moon",
+      "bench",
+      "--target",
+      "js",
+      "-p",
+      "mizchi/luna/core/stream_render",
+      "-f",
+      "stream_render_bench.mbt",
+      "-i",
+      "0-3",
+    ],
+    include: new Set([
+      "stream render: list (10 items)",
+      "stream render: large_list (100 items with escape)",
+      "stream render: page",
+    ]),
+  },
 ];
 
 function parseArgs() {

--- a/luna/src/core/stream_render/moon.pkg
+++ b/luna/src/core/stream_render/moon.pkg
@@ -1,12 +1,13 @@
 import {
-  "mizchi/luna/core" @core,
-  "mizchi/luna" @luna,
-  "mizchi/luna/core/render" @render,
+  "mizchi/luna/core",
+  "mizchi/luna",
+  "mizchi/luna/core/render",
+  "moonbitlang/core/bench",
 }
 
 import {
   "moonbitlang/async",
-  "moonbitlang/core/test" @test,
+  "moonbitlang/core/test",
 } for "test"
 
 supported_targets = "all"

--- a/luna/src/core/stream_render/stream_render_bench.mbt
+++ b/luna/src/core/stream_render/stream_render_bench.mbt
@@ -1,0 +1,80 @@
+// Benchmarks for portable stream rendering
+
+///|
+fn vnode_stream_list() -> @luna.Node[Unit, String] {
+  let items : Array[@luna.Node[Unit, String]] = []
+  for i in 0..<10 {
+    items.push(
+      @luna.h("li", [("class", @luna.attr_static("item"))], [
+        @luna.text("Item \{i}"),
+      ]),
+    )
+  }
+  @luna.h("ul", [("class", @luna.attr_static("list"))], items)
+}
+
+///|
+fn vnode_stream_large_list() -> @luna.Node[Unit, String] {
+  let items : Array[@luna.Node[Unit, String]] = []
+  for i in 0..<100 {
+    items.push(
+      @luna.h("li", [("class", @luna.attr_static("item"))], [
+        @luna.text("Item \{i} with some <special> & \"characters\""),
+      ]),
+    )
+  }
+  @luna.h("ul", [("class", @luna.attr_static("list"))], items)
+}
+
+///|
+fn vnode_stream_page() -> @luna.Node[Unit, String] {
+  @luna.h("html", [], [
+    @luna.h("head", [], [
+      @luna.h("meta", [("charset", @luna.attr_static("utf-8"))], []),
+      @luna.h("title", [], [@luna.text("Test Page")]),
+    ]),
+    @luna.h("body", [], [
+      @luna.h("header", [], [
+        @luna.h("nav", [("class", @luna.attr_static("navbar"))], [
+          @luna.h("a", [("href", @luna.attr_static("/"))], [@luna.text("Home")]),
+          @luna.h("a", [("href", @luna.attr_static("/about"))], [
+            @luna.text("About"),
+          ]),
+        ]),
+      ]),
+      @luna.h("main", [("class", @luna.attr_static("container"))], [
+        @luna.h("h1", [], [@luna.text("Welcome")]),
+        @luna.h("p", [], [
+          @luna.text("This is a test page with <special> & \"characters\"."),
+        ]),
+      ]),
+      @luna.h("footer", [], [@luna.text("© 2024")]),
+    ]),
+  ])
+}
+
+///|
+fn stream_to_string(node : @luna.Node[Unit, String]) -> String {
+  let sb = StringBuilder::new(size_hint=1024)
+  let writer = StreamWriter::from_callback(fn(chunk) { sb.write_string(chunk) })
+  render_to_stream(node, writer)
+  sb.to_string()
+}
+
+///|
+test "stream render: list (10 items)" (b : @bench.T) {
+  let node = vnode_stream_list()
+  b.bench(fn() { b.keep(stream_to_string(node)) })
+}
+
+///|
+test "stream render: large_list (100 items with escape)" (b : @bench.T) {
+  let node = vnode_stream_large_list()
+  b.bench(fn() { b.keep(stream_to_string(node)) })
+}
+
+///|
+test "stream render: page" (b : @bench.T) {
+  let node = vnode_stream_page()
+  b.bench(fn() { b.keep(stream_to_string(node)) })
+}


### PR DESCRIPTION
## Summary
- add portable stream renderer MoonBit benchmarks for list, large list, and page cases
- include the stream renderer suite in moonbench regression checks
- refresh MoonBench baseline after the SSR escaping optimization from PR #95

## Notes
- tried a stream renderer helper/size-hint allocation change, but it regressed the stream benchmark and was not kept
- this PR only adds benchmark coverage and baseline updates

## Validation
- moon test --target js -p mizchi/luna/core/stream_render: 10 passed
- moon test --target js -p mizchi/luna/js/stream_renderer: 59 passed
- just moonbench-check
- just check
- just test-moonbit: 2819 passed
- just treeshake-size: unchanged client sizes
- just bundle-size: unchanged loader sizes