### PR TITLE
feat: add form actions popover and perf smoke

### DIFF
--- a/luna/e2e/performance-smoke.test.ts
+++ b/luna/e2e/performance-smoke.test.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+const LOAD_BUDGET_MS = 5000;
+const HYDRATION_BUDGET_MS = 5000;
+const INTERACTION_BUDGET_MS = 1000;
+
+test.describe("performance smoke", () => {
+  test("spa reaches first usable heading within budget", async ({ page }) => {
+    await page.goto("/spa");
+    await expect(page.getByRole("heading", { name: "Luna Examples" })).toBeVisible();
+
+    const timing = await page.evaluate(() => {
+      const nav = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+      return {
+        domContentLoaded: nav ? nav.domContentLoadedEventEnd - nav.startTime : 0,
+        load: nav && nav.loadEventEnd > 0 ? nav.loadEventEnd - nav.startTime : 0,
+      };
+    });
+
+    expect(timing.domContentLoaded).toBeGreaterThan(0);
+    expect(timing.domContentLoaded).toBeLessThan(LOAD_BUDGET_MS);
+    if (timing.load > 0) {
+      expect(timing.load).toBeLessThan(LOAD_BUDGET_MS);
+    }
+  });
+
+  test("counter first interaction commits within budget", async ({ page }) => {
+    await page.goto("/spa");
+    const counter = page.locator(".counter-example");
+    await expect(counter).toBeVisible();
+    await expect(counter.locator("p").first()).toContainText("Count: 0");
+
+    const elapsed = await page.evaluate(async () => {
+      const section = document.querySelector(".counter-example");
+      if (!section) throw new Error("counter section not found");
+      const button = Array.from(section.querySelectorAll("button")).find((el) =>
+        el.textContent?.includes("+"),
+      );
+      const count = section.querySelector("p");
+      if (!button || !count) throw new Error("counter controls not found");
+
+      const start = performance.now();
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+      await new Promise<void>((resolve, reject) => {
+        const deadline = window.setTimeout(() => {
+          observer.disconnect();
+          reject(new Error("counter update timed out"));
+        }, 1000);
+        const observer = new MutationObserver(() => {
+          if (count.textContent?.includes("Count: 1")) {
+            window.clearTimeout(deadline);
+            observer.disconnect();
+            resolve();
+          }
+        });
+        observer.observe(count, { childList: true, characterData: true, subtree: true });
+        if (count.textContent?.includes("Count: 1")) {
+          window.clearTimeout(deadline);
+          observer.disconnect();
+          resolve();
+        }
+      });
+
+      return performance.now() - start;
+    });
+
+    expect(elapsed).toBeLessThan(INTERACTION_BUDGET_MS);
+    await expect(counter.locator("p").first()).toContainText("Count: 1");
+  });
+
+  test("hydrated browser example becomes usable within budget", async ({ page }) => {
+    await page.goto("/browser/signal-effect");
+
+    const app = page.locator("#app");
+    await expect(app).toHaveAttribute("data-hydrated", "true");
+    await expect(page.locator("[data-count]")).toHaveText("5");
+
+    const hydratedAt = await page.evaluate(() => {
+      const nav = performance.getEntriesByType("navigation")[0] as PerformanceNavigationTiming | undefined;
+      return performance.now() - (nav?.startTime ?? 0);
+    });
+
+    expect(hydratedAt).toBeLessThan(HYDRATION_BUDGET_MS);
+
+    await page.locator("[data-inc]").click();
+    await expect(page.locator("[data-count]")).toHaveText("6");
+  });
+});

--- a/luna_components/src/pkg.generated.mbti
+++ b/luna_components/src/pkg.generated.mbti
@@ -233,6 +233,12 @@ pub fn[E] option_dyn(String, @signals.Signal[Array[String]], disabled? : Bool, A
 
 pub fn[E] page_layout(header? : Array[@mizchi/luna/core.Node[E, String]], nav_content? : Array[@mizchi/luna/core.Node[E, String]], Array[@mizchi/luna/core.Node[E, String]], aside_content? : Array[@mizchi/luna/core.Node[E, String]], footer_content? : Array[@mizchi/luna/core.Node[E, String]]) -> @mizchi/luna/core.Node[E, String]
 
+pub fn[E] popover(String, mode? : PopoverMode, role? : String, aria_label? : String, aria_labelledby? : String, class? : String, Array[@mizchi/luna/core.Node[E, String]]) -> @mizchi/luna/core.Node[E, String]
+
+pub fn[E] popover_dialog(String, mode? : PopoverMode, aria_label? : String, aria_labelledby? : String, class? : String, Array[@mizchi/luna/core.Node[E, String]]) -> @mizchi/luna/core.Node[E, String]
+
+pub fn[E] popover_trigger(String, action? : PopoverTargetAction, id? : String, aria_label? : String, class? : String, Array[@mizchi/luna/core.Node[E, String]]) -> @mizchi/luna/core.Node[E, String]
+
 pub fn[E] radio(String, Bool, disabled? : Bool, on_click? : @mizchi/luna/core.EventHandler[E], on_keydown? : @mizchi/luna/core.EventHandler[E], Array[@mizchi/luna/core.Node[E, String]]) -> @mizchi/luna/core.Node[E, String]
 
 pub fn[E] radio_computed(String, () -> Bool, disabled? : Bool, on_click? : @mizchi/luna/core.EventHandler[E], on_keydown? : @mizchi/luna/core.EventHandler[E], Array[@mizchi/luna/core.Node[E, String]]) -> @mizchi/luna/core.Node[E, String]
@@ -460,6 +466,17 @@ pub(all) struct MenuItem {
   label : String
   disabled : Bool
 }
+
+pub(all) enum PopoverMode {
+  Auto
+  Manual
+} derive(Eq, @debug.Debug)
+
+pub(all) enum PopoverTargetAction {
+  Toggle
+  Show
+  Hide
+} derive(Eq, @debug.Debug)
 
 pub(all) enum PopupType {
   Menu

--- a/luna_components/src/popover.mbt
+++ b/luna_components/src/popover.mbt
@@ -1,0 +1,122 @@
+///|
+/// Native HTML Popover API mode.
+pub(all) enum PopoverMode {
+  /// Light-dismiss popover. This is the browser default.
+  Auto
+  /// Manual popover, closed explicitly by script or a target button.
+  Manual
+} derive(Eq, Debug)
+
+///|
+/// Native `popovertargetaction` values for controls targeting a popover.
+pub(all) enum PopoverTargetAction {
+  Toggle
+  Show
+  Hide
+} derive(Eq, Debug)
+
+///|
+fn popover_mode_to_string(mode : PopoverMode) -> String {
+  match mode {
+    Auto => "auto"
+    Manual => "manual"
+  }
+}
+
+///|
+fn popover_action_to_string(action : PopoverTargetAction) -> String {
+  match action {
+    Toggle => "toggle"
+    Show => "show"
+    Hide => "hide"
+  }
+}
+
+///|
+/// Create a zero-runtime native popover container.
+///
+/// The browser owns open/close behavior through the HTML Popover API. Pair this
+/// with `popover_trigger` to avoid adding a client-side controller for common
+/// menus, help panels, and non-modal dialogs.
+pub fn[E] popover(
+  id : String,
+  mode? : PopoverMode,
+  role? : String,
+  aria_label? : String,
+  aria_labelledby? : String,
+  class? : String,
+  children : Array[@luna.Node[E, String]],
+) -> @luna.Node[E, String] {
+  let attrs : Array[(String, @luna.Attr[E, String])] = [
+    ("id", @luna.attr_static(id)),
+    ("popover", @luna.attr_static(popover_mode_to_string(mode.unwrap_or(Auto)))),
+  ]
+  if role is Some(value) {
+    attrs.push(("role", @luna.attr_static(value)))
+  }
+  if aria_label is Some(value) {
+    attrs.push(("aria-label", @luna.attr_static(value)))
+  }
+  if aria_labelledby is Some(value) {
+    attrs.push(("aria-labelledby", @luna.attr_static(value)))
+  }
+  if class is Some(value) {
+    attrs.push(("class", @luna.attr_static(value)))
+  }
+  @luna.h("div", attrs) <| children
+}
+
+///|
+/// Create a button that controls a native popover.
+pub fn[E] popover_trigger(
+  target : String,
+  action? : PopoverTargetAction,
+  id? : String,
+  aria_label? : String,
+  class? : String,
+  children : Array[@luna.Node[E, String]],
+) -> @luna.Node[E, String] {
+  let attrs : Array[(String, @luna.Attr[E, String])] = [
+    ("type", @luna.attr_static("button")),
+    ("popovertarget", @luna.attr_static(target)),
+  ]
+  if action is Some(value) {
+    attrs.push(
+      (
+        "popovertargetaction",
+        @luna.attr_static(popover_action_to_string(value)),
+      ),
+    )
+  }
+  if id is Some(value) {
+    attrs.push(("id", @luna.attr_static(value)))
+  }
+  if aria_label is Some(value) {
+    attrs.push(("aria-label", @luna.attr_static(value)))
+  }
+  if class is Some(value) {
+    attrs.push(("class", @luna.attr_static(value)))
+  }
+  @luna.h("button", attrs) <| children
+}
+
+///|
+/// Create a non-modal dialog surface backed by the native Popover API.
+pub fn[E] popover_dialog(
+  id : String,
+  mode? : PopoverMode,
+  aria_label? : String,
+  aria_labelledby? : String,
+  class? : String,
+  children : Array[@luna.Node[E, String]],
+) -> @luna.Node[E, String] {
+  popover(
+    id,
+    mode?,
+    role="dialog",
+    aria_label?,
+    aria_labelledby?,
+    class?,
+    children,
+  )
+}

--- a/luna_components/src/popover_test.mbt
+++ b/luna_components/src/popover_test.mbt
@@ -1,0 +1,93 @@
+///|
+test "popover: uses native popover attribute" {
+  let node : @luna.Node[Unit, String] = popover("menu-popover", [
+    @luna.text("Menu"),
+  ])
+  guard node is @core.Element(el) else { fail("expected Element") }
+  inspect(el.tag, content="div")
+  let mut has_id = false
+  let mut has_popover = false
+  for attr in el.attrs {
+    if attr.0 == "id" {
+      guard attr.1 is @core.VStatic("menu-popover") else { fail("wrong id") }
+      has_id = true
+    }
+    if attr.0 == "popover" {
+      guard attr.1 is @core.VStatic("auto") else { fail("wrong popover mode") }
+      has_popover = true
+    }
+  }
+  inspect(has_id, content="true")
+  inspect(has_popover, content="true")
+}
+
+///|
+test "popover: supports manual mode and dialog role" {
+  let node : @luna.Node[Unit, String] = popover(
+    "confirm-popover",
+    mode=Manual,
+    role="dialog",
+    aria_labelledby="confirm-title",
+    [],
+  )
+  guard node is @core.Element(el) else { fail("expected Element") }
+  let mut has_manual = false
+  let mut has_role = false
+  let mut has_labelledby = false
+  for attr in el.attrs {
+    if attr.0 == "popover" {
+      guard attr.1 is @core.VStatic("manual") else {
+        fail("wrong popover mode")
+      }
+      has_manual = true
+    }
+    if attr.0 == "role" {
+      guard attr.1 is @core.VStatic("dialog") else { fail("wrong role") }
+      has_role = true
+    }
+    if attr.0 == "aria-labelledby" {
+      guard attr.1 is @core.VStatic("confirm-title") else {
+        fail("wrong labelledby")
+      }
+      has_labelledby = true
+    }
+  }
+  inspect(has_manual, content="true")
+  inspect(has_role, content="true")
+  inspect(has_labelledby, content="true")
+}
+
+///|
+test "popover_trigger: targets popover without client runtime" {
+  let node : @luna.Node[Unit, String] = popover_trigger(
+    "menu-popover",
+    action=Toggle,
+    [@luna.text("Open menu")],
+  )
+  guard node is @core.Element(el) else { fail("expected Element") }
+  inspect(el.tag, content="button")
+  let mut has_type = false
+  let mut has_target = false
+  let mut has_action = false
+  for attr in el.attrs {
+    if attr.0 == "type" {
+      guard attr.1 is @core.VStatic("button") else { fail("wrong type") }
+      has_type = true
+    }
+    if attr.0 == "popovertarget" {
+      guard attr.1 is @core.VStatic("menu-popover") else {
+        fail("wrong target")
+      }
+      has_target = true
+    }
+    if attr.0 == "popovertargetaction" {
+      guard attr.1 is @core.VStatic("toggle") else {
+        fail("wrong target action")
+      }
+      has_action = true
+    }
+  }
+  inspect(has_type, content="true")
+  inspect(has_target, content="true")
+  inspect(has_action, content="true")
+}

--- a/sol/src/action/action_wbtest.mbt
+++ b/sol/src/action/action_wbtest.mbt
@@ -123,12 +123,12 @@ test "ActionResult::server_error creates 500 error" {
 priv struct CreateUserActionKey {}
 
 ///|
-impl ActionKey for CreateUserActionKey with id(_self) {
+impl ActionKey for CreateUserActionKey with fn id(_self) {
   "create-user"
 }
 
 ///|
-impl ActionKey for CreateUserActionKey with base_path(_self) {
+impl ActionKey for CreateUserActionKey with fn base_path(_self) {
   "/_action"
 }
 
@@ -136,12 +136,12 @@ impl ActionKey for CreateUserActionKey with base_path(_self) {
 priv struct GetUserActionKey {}
 
 ///|
-impl ActionKey for GetUserActionKey with id(_self) {
+impl ActionKey for GetUserActionKey with fn id(_self) {
   "get-user"
 }
 
 ///|
-impl ActionKey for GetUserActionKey with base_path(_self) {
+impl ActionKey for GetUserActionKey with fn base_path(_self) {
   "/_action"
 }
 
@@ -149,12 +149,12 @@ impl ActionKey for GetUserActionKey with base_path(_self) {
 priv struct ActionOneKey {}
 
 ///|
-impl ActionKey for ActionOneKey with id(_self) {
+impl ActionKey for ActionOneKey with fn id(_self) {
   "action1"
 }
 
 ///|
-impl ActionKey for ActionOneKey with base_path(_self) {
+impl ActionKey for ActionOneKey with fn base_path(_self) {
   "/_action"
 }
 
@@ -162,12 +162,12 @@ impl ActionKey for ActionOneKey with base_path(_self) {
 priv struct ActionTwoKey {}
 
 ///|
-impl ActionKey for ActionTwoKey with id(_self) {
+impl ActionKey for ActionTwoKey with fn id(_self) {
   "action2"
 }
 
 ///|
-impl ActionKey for ActionTwoKey with base_path(_self) {
+impl ActionKey for ActionTwoKey with fn base_path(_self) {
   "/_action"
 }
 
@@ -182,6 +182,13 @@ test "action_url builds endpoint URL from action key" {
 priv struct CreateUserRequest {
   name : String
 } derive(ToJson, FromJson)
+
+///|
+priv struct ContactRequest {
+  name : String
+  email : String
+  message : String
+} derive(FromJson)
 
 ///|
 priv struct CreateUserResponse {
@@ -226,6 +233,40 @@ test "decode_action_body decodes typed JSON request bodies" {
 ///|
 test "decode_action_body rejects invalid request bodies" {
   let decoded : CreateUserRequest? = decode_action_body("{\"unexpected\":true}")
+  assert_true(decoded is None)
+}
+
+///|
+test "decode_action_form_urlencoded decodes typed form payloads" {
+  let decoded : CreateUserRequest? = decode_action_form_urlencoded(
+    "name=Alice+Smith",
+  )
+  match decoded {
+    Some(req) => assert_eq(req.name, "Alice Smith")
+    None => fail("expected decoded form payload")
+  }
+}
+
+///|
+test "decode_action_form_urlencoded decodes percent-encoded utf8" {
+  let decoded : ContactRequest? = decode_action_form_urlencoded(
+    "name=%E6%9C%88&email=a%40example.test&message=hello+world",
+  )
+  match decoded {
+    Some(req) => {
+      assert_eq(req.name, "月")
+      assert_eq(req.email, "a@example.test")
+      assert_eq(req.message, "hello world")
+    }
+    None => fail("expected decoded contact form")
+  }
+}
+
+///|
+test "decode_action_form_urlencoded rejects missing required fields" {
+  let decoded : CreateUserRequest? = decode_action_form_urlencoded(
+    "unexpected=true",
+  )
   assert_true(decoded is None)
 }
 

--- a/sol/src/action/moon.pkg
+++ b/sol/src/action/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/async/js_async",
   "mizchi/js_browser/dom" @js_dom,
   "mizchi/mars",

--- a/sol/src/action/pkg.generated.mbti
+++ b/sol/src/action/pkg.generated.mbti
@@ -19,6 +19,8 @@ pub fn[Req : ToJson, Res : @json.FromJson] create_typed_action_invoker_key(Typed
 
 pub fn[T : @json.FromJson] decode_action_body(String) -> T?
 
+pub fn[T : @json.FromJson] decode_action_form_urlencoded(String) -> T?
+
 pub fn[Req : ToJson, Res : @json.FromJson] invoke_typed_action_key(TypedActionKey[Req, Res], Req, (TypedActionResponse[Res]) -> Unit, options? : ActionOptions) -> Unit
 
 pub fn register_actions(@mars.Server, ActionRegistry) -> Unit
@@ -34,6 +36,7 @@ pub struct ActionContext {
   ctx : @mars.Context
   body : String
 }
+pub fn[T : @json.FromJson] ActionContext::decode_form_urlencoded(Self) -> T?
 pub fn[T : @json.FromJson] ActionContext::decode_json(Self) -> T?
 pub fn ActionContext::from_ctx(@mars.Context, String) -> Self
 pub fn ActionContext::get_header(Self, String) -> String?

--- a/sol/src/action/types.mbt
+++ b/sol/src/action/types.mbt
@@ -34,9 +34,120 @@ pub fn[T : FromJson] decode_action_body(body : String) -> T? {
 }
 
 ///|
+/// Decode an `application/x-www-form-urlencoded` action body as a typed payload.
+/// Field values are normalized to JSON strings and decoded through `FromJson`,
+/// which keeps the server action contract identical to JSON submissions.
+pub fn[T : FromJson] decode_action_form_urlencoded(body : String) -> T? {
+  let obj : Map[String, Json] = {}
+  for pair_view in body.split("&") {
+    let pair = pair_view.to_owned()
+    if pair.is_empty() {
+      continue
+    }
+    let (raw_key, raw_value) = match pair.split_once("=") {
+      Some((key, value)) => (key.to_owned(), value.to_owned())
+      None => (pair, "")
+    }
+    let key = decode_form_component(raw_key)
+    if key.is_empty() {
+      continue
+    }
+    obj[key] = Json::string(decode_form_component(raw_value))
+  }
+  let value : T = @json.from_json(Json::object(obj)) catch { _ => return None }
+  Some(value)
+}
+
+///|
 /// Decode this action request body as typed JSON.
 pub fn[T : FromJson] ActionContext::decode_json(self : ActionContext) -> T? {
   decode_action_body(self.body)
+}
+
+///|
+/// Decode this action request body as `application/x-www-form-urlencoded`.
+pub fn[T : FromJson] ActionContext::decode_form_urlencoded(
+  self : ActionContext,
+) -> T? {
+  decode_action_form_urlencoded(self.body)
+}
+
+///|
+fn decode_form_component(s : String) -> String {
+  let chars = s.to_array()
+  let len = chars.length()
+  let sb = StringBuilder::new(size_hint=len)
+  let mut i = 0
+  while i < len {
+    let c = chars[i]
+    let has_percent_triplet = c == '%' &&
+      i + 2 < len &&
+      is_hex_digit(chars[i + 1]) &&
+      is_hex_digit(chars[i + 2])
+    if c == '+' {
+      sb.write_char(' ')
+      i += 1
+    } else if has_percent_triplet {
+      let (decoded, next_i) = decode_percent_encoded_bytes(chars, i, len)
+      sb.write_string(decoded)
+      i = next_i
+    } else {
+      sb.write_char(c)
+      i += 1
+    }
+  }
+  sb.to_string()
+}
+
+///|
+fn decode_percent_encoded_bytes(
+  chars : Array[Char],
+  start : Int,
+  len : Int,
+) -> (String, Int) {
+  let bytes : Array[Byte] = []
+  let mut i = start
+  while i + 2 < len && chars[i] == '%' {
+    let hi = chars[i + 1]
+    let lo = chars[i + 2]
+    if !(is_hex_digit(hi) && is_hex_digit(lo)) {
+      break
+    }
+    let byte = hex_digit_to_int(hi) * 16 + hex_digit_to_int(lo)
+    bytes.push(byte.to_byte())
+    i += 3
+  }
+  (decode_percent_bytes(bytes), i)
+}
+
+///|
+fn decode_percent_bytes(bytes : Array[Byte]) -> String {
+  let raw = Bytes::from_array(bytes)
+  @utf8.decode(raw) catch {
+    _ => {
+      let fallback : Array[Char] = []
+      for b in bytes {
+        fallback.push(b.to_int().unsafe_to_char())
+      }
+      String::from_array(fallback)
+    }
+  }
+}
+
+///|
+fn is_hex_digit(c : Char) -> Bool {
+  (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+///|
+fn hex_digit_to_int(c : Char) -> Int {
+  if c >= '0' && c <= '9' {
+    c.to_int() - '0'.to_int()
+  } else if c >= 'a' && c <= 'f' {
+    c.to_int() - 'a'.to_int() + 10
+  } else {
+    c.to_int() - 'A'.to_int() + 10
+  }
 }
 
 ///|
@@ -161,10 +272,10 @@ pub(all) struct ActionHandler(async (ActionContext) -> ActionResult raise Error)
 /// Action key implemented by generated marker types.
 pub(open) trait ActionKey {
   /// Stable action identifier used in the HTTP endpoint.
-  id(Self) -> String
+  fn id(Self) -> String
 
   /// Base path for action endpoints.
-  base_path(Self) -> String
+  fn base_path(Self) -> String
 }
 
 ///|
@@ -204,12 +315,14 @@ pub fn[Req, Res] TypedActionKey::base_path(
 }
 
 ///|
-pub impl[Req, Res] ActionKey for TypedActionKey[Req, Res] with id(self) {
+pub impl[Req, Res] ActionKey for TypedActionKey[Req, Res] with fn id(self) {
   self.id
 }
 
 ///|
-pub impl[Req, Res] ActionKey for TypedActionKey[Req, Res] with base_path(self) {
+pub impl[Req, Res] ActionKey for TypedActionKey[Req, Res] with fn base_path(
+  self,
+) {
   self.base_path
 }
 


### PR DESCRIPTION
## Summary
- add typed form-urlencoded decoding for Sol server actions
- add zero-runtime native Popover API components to luna_components
- add Playwright performance smoke coverage for SPA load, hydration, and first interaction

## Validation
- just check
- just test-moonbit (2825 passed)
- just test-vitest (705 passed)
- just test-e2e (171 passed)
- pnpm tsc -b
- just bundle-check (passed, no loader bundle regression)
- just treeshake-check (baseline matches, no client bundle increase)
- just runtime-check
- just moonbench-check
- git diff --check

## Notes
- Client bundle size is unchanged against the existing bundle and treeshake baselines.