### PR TITLE
chore: keep release-please pre-1.0 (breaking changes bump minor)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "release-type": "node",
   "include-component-in-tag": true,
   "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "plugins": ["node-workspace"],
   "packages": {
     "js/luna":        { "package-name": "@luna_ui/luna" },


### PR DESCRIPTION
mizchi/mooncakes cannot currently publish a major (1.0.0) version, and the `@luna_ui/*` npm packages are version-aligned with their mooncakes. Accumulated `BREAKING CHANGE` commits were driving release-please to compute **1.0.0** for the pending Release PR (#90) — merging it would have broken the coordinated mooncake publish.

Set `bump-minor-pre-major: true` so breaking changes bump the **minor** version (0.22 → 0.23) while majors stay at 0. After this lands, re-running release-please recomputes the Release PR to 0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)