### PR TITLE
chore: decouple npm release tags from mooncake tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. luna-v0.17.0)'
+        description: 'Tag to publish (e.g. luna-npm-v0.23.1)'
         required: true
 
 permissions:
@@ -66,10 +66,12 @@ jobs:
       # per-package matrix here.
       - run: pnpm -r build
 
-      # release-please tag format is "<component>-v<version>" where component
-      # defaults to the package name without scope (e.g. "luna" for
-      # "@luna_ui/luna"). Reconstruct the full scoped name with the @luna_ui
-      # prefix, then walk js/*/package.json to find the matching directory.
+      # release-please tag format is "<component>-v<version>". Each npm package
+      # sets component to "<name>-npm" in release-please-config.json so these
+      # tags (e.g. "luna-npm-v0.23.1") never collide with the mooncake release
+      # flow's "<name>-v<version>" tags (cut by `just vup`). Strip the "-v*"
+      # version suffix, then the trailing "-npm" component suffix, to recover
+      # the package name; walk js/*/package.json to find the matching directory.
       - name: Resolve package directory from tag
         id: pkg
         env:
@@ -77,6 +79,7 @@ jobs:
         run: |
           TAG="${DISPATCH_TAG:-$GITHUB_REF_NAME}"
           COMPONENT="${TAG%-v*}"
+          COMPONENT="${COMPONENT%-npm}"
           NAME="@luna_ui/${COMPONENT}"
           DIR=""
           for f in js/*/package.json; do

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,13 +7,13 @@
   "bump-patch-for-minor-pre-major": false,
   "plugins": ["node-workspace"],
   "packages": {
-    "js/luna":        { "package-name": "@luna_ui/luna" },
-    "js/sol":         { "package-name": "@luna_ui/sol" },
-    "js/astra":       { "package-name": "@luna_ui/astra" },
-    "js/components":  { "package-name": "@luna_ui/components" },
-    "js/loader":      { "package-name": "@luna_ui/luna-loader" },
-    "js/stella":      { "package-name": "@luna_ui/stella" },
-    "js/testing":     { "package-name": "@luna_ui/testing" },
-    "js/wcr":         { "package-name": "@luna_ui/wcr" }
+    "js/luna":        { "package-name": "@luna_ui/luna",        "component": "luna-npm" },
+    "js/sol":         { "package-name": "@luna_ui/sol",         "component": "sol-npm" },
+    "js/astra":       { "package-name": "@luna_ui/astra",       "component": "astra-npm" },
+    "js/components":  { "package-name": "@luna_ui/components",   "component": "components-npm" },
+    "js/loader":      { "package-name": "@luna_ui/luna-loader", "component": "luna-loader-npm" },
+    "js/stella":      { "package-name": "@luna_ui/stella",      "component": "stella-npm" },
+    "js/testing":     { "package-name": "@luna_ui/testing",     "component": "testing-npm" },
+    "js/wcr":         { "package-name": "@luna_ui/wcr",         "component": "wcr-npm" }
   }
 }


### PR DESCRIPTION
## Problem

The mooncake release flow (`just vup` / `release-mooncakes`) and release-please **both** tag `<name>-v<version>`. When a mooncake was released first (e.g. `luna-v0.23.0`), release-please reused that stale tag instead of creating a fresh one, and `publish.yml` checked out the wrong commit — publishing the **old** npm version and failing with "cannot publish over the previously published version". Recovering the 0.23.0 npm release required manually force-moving `luna-v0.23.0` / `sol-v0.23.0` / `astra-v0.23.0` to the release merge commit.

## Fix

Give each npm package a `-npm` **component** suffix in `release-please-config.json`, so release-please cuts tags like `luna-npm-v0.23.1` that never overlap the mooncake `luna-v*` namespace.

`publish.yml`'s tag→directory resolver strips the `-npm` suffix (after the `-v*` version suffix) to recover the package name. Verified locally that all 8 new-style tags map back to the correct `js/*` package:

| new tag | → package |
|---|---|
| `luna-npm-v0.23.1` | `@luna_ui/luna` (js/luna) |
| `sol-npm-v0.23.1` | `@luna_ui/sol` (js/sol) |
| `astra-npm-v0.23.1` | `@luna_ui/astra` (js/astra) |
| `components-npm-v0.23.1` | `@luna_ui/components` (js/components) |
| `luna-loader-npm-v0.23.1` | `@luna_ui/luna-loader` (js/loader) |
| `stella-npm-v0.23.1` | `@luna_ui/stella` (js/stella) |
| `testing-npm-v0.23.1` | `@luna_ui/testing` (js/testing) |
| `wcr-npm-v0.23.1` | `@luna_ui/wcr` (js/wcr) |

## Notes

- release-please is manifest-driven (`.release-please-manifest.json` pins each package at `0.23.0`), so the version stream continues unaffected by the component rename — only the tag *names* change going forward.
- Existing `0.23.0` GitHub Releases/tags are untouched; this only affects future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)