### PR TITLE
fix(sol,astra): sanitize header values to prevent CRLF injection (CWE-113)

### DIFF
--- a/astra/src/middleware/middleware.mbt
+++ b/astra/src/middleware/middleware.mbt
@@ -87,7 +87,8 @@ fn dispatch(mw : Middleware, ctx : @mars.Context) -> Unit {
   // `set_header` before `text` so the explicit Content-Type wins over
   // mars's text-helper default (`text/plain`). The same rule applied in
   // the previous asset path; it now covers pages too.
-  ctx.set_header("Content-Type", res.content_type)
+  let content_type = res.content_type.replace_all(old="\r", new="").replace_all(old="\n", new="")
+  ctx.set_header("Content-Type", content_type)
   ctx.text(res.body, status=res.status)
 }
 

--- a/sol/src/router/mbtx_handler.mbt
+++ b/sol/src/router/mbtx_handler.mbt
@@ -32,7 +32,8 @@ pub fn register_mbtx_routes(app : App, routes : Array[MbtxRoute]) -> Unit {
           c.text("Internal Server Error", status=500)
           return
         }
-        c.set_header("Content-Type", result.content_type)
+        let content_type = result.content_type.replace_all(old="\r", new="").replace_all(old="\n", new="")
+        c.set_header("Content-Type", content_type)
         c.text(result.body, status=result.status)
       }),
     )

--- a/sol/src/router/route_params.mbt
+++ b/sol/src/router/route_params.mbt
@@ -235,7 +235,10 @@ pub fn PageProps::set_header(
   if self.is_isr_render {
     ()
   } else {
-    self.ctx.set_header(name, value)
+    // Strip CRLF to prevent header injection (CWE-113)
+    let safe_name = name.replace_all(old="\r", new="").replace_all(old="\n", new="")
+    let safe_value = value.replace_all(old="\r", new="").replace_all(old="\n", new="")
+    self.ctx.set_header(safe_name, safe_value)
   }
 }
 


### PR DESCRIPTION
## Summary

`PageProps::set_header` and two internal `set_header` call sites forward user-controllable values to mars `Context::set_header` without stripping CR/LF characters. When the HTTP response is built, Node.js `Headers.set()` throws `TypeError` on `\r\n`, causing **500 Internal Server Error** on every request carrying a CRLF payload.

**Affected paths:**
- `sol/src/router/route_params.mbt:230` — public `PageProps::set_header(name, value)` API
- `sol/src/router/mbtx_handler.mbt:35` — `content_type` from mbtx FFI execution
- `astra/src/middleware/middleware.mbt:90` — `content_type` from page render result

**Fix:** strip `\r` and `\n` from header name/value via `replace_all` before forwarding to mars.

## Reproduction

```bash
# Start sol_app example
cd sol/examples/sol_app
node .sol/dev/server/serve.js &

# Trigger 500 via CRLF in header value (using hono directly)
node -e "
import { Hono } from 'hono';
const app = new Hono();
app.get('/test', c => { c.header('X-Lang', 'en\r\nEvil: true'); return c.text('ok'); });
const r = await app.fetch(new Request('http://localhost/test'));
console.log('Status:', r.status);  // 500
"
```

## Root cause

```moonbit
// mars/src/context.mbt:104-110 — no CRLF validation
pub fn Context::set_header(self : Context, name : String, value : String) -> Unit {
  self.response_headers.set(name, value)  // stored as-is
}
// Later: new Response(body, { headers }) → Node.js Headers.set() throws TypeError
```

> Note: The root cause is in mars `Context::set_header`. This PR fixes the sol/astra layer as defense-in-depth; a corresponding fix in mars would prevent the issue for all mars users.