### PR TITLE
fix(sol): emit source-relative bundle paths, not module-name-prefixed

### DIFF
--- a/sol/src/cli/build_package_path_wbtest.mbt
+++ b/sol/src/cli/build_package_path_wbtest.mbt
@@ -1,0 +1,29 @@
+// Regression tests for `build_package_path`.
+//
+// moon emits build artifacts under `_build/js/{profile}/build/` using the
+// package path *relative to the module's `source` root* — the module name
+// never appears in the build path. `build_package_path` must therefore return
+// the source-relative path so that the generated `.sol` stubs import a file
+// that actually exists on disk. Prepending the module name here previously
+// broke `sol build`'s bundling step (unresolved import) even though
+// `moon check` / `moon test` stayed green.
+
+///|
+test "build_package_path strips the source root and omits the module name" {
+  // source = "app": app/client -> client
+  assert_eq(build_package_path("uuu/deli-cms-sol", "app", "app/client"), "client")
+  // nested generated package: src/__gen__/server -> __gen__/server
+  assert_eq(
+    build_package_path("tester/myapp", "src", "src/__gen__/server"),
+    "__gen__/server",
+  )
+}
+
+///|
+test "build_package_path leaves the path unchanged when there is no source root" {
+  // source = "." or "": package path is already module-root relative.
+  assert_eq(build_package_path("tester/myapp", ".", "client"), "client")
+  assert_eq(build_package_path("tester/myapp", "", "server"), "server")
+  // package outside the declared source dir is left untouched.
+  assert_eq(build_package_path("tester/myapp", "app", "vendor/x"), "vendor/x")
+}

--- a/sol/src/cli/generate.mbt
+++ b/sol/src/cli/generate.mbt
@@ -17,22 +17,32 @@
 // =============================================================================
 
 ///|
+/// Build the on-disk package path that `moon` emits under
+/// `_build/js/{profile}/build/`.
+///
+/// moon's build output is **source-relative** — for a module whose `source`
+/// is `app`, the package `app/client` is emitted to
+/// `_build/js/{profile}/build/client/client.js`. The module name from
+/// `moon.mod`'s `name` field does **not** appear in the build path.
+///
+/// Prepending `mod_name` here produced references to
+/// `_build/js/{profile}/build/{mod_name}/{rel}/...` which do not exist on
+/// disk, so `sol build`'s bundling step failed with an unresolved import
+/// (this regressed against 0.23.0, which used the source-relative path).
+/// `moon check` / `moon test` don't surface it because they never run the
+/// bundler. `mod_name` is retained in the signature for call-site
+/// compatibility but is intentionally unused.
 fn build_package_path(
-  mod_name : String,
+  _mod_name : String,
   source_dir : String,
   package_dir : String,
 ) -> String {
-  let relative_path = if source_dir.length() > 0 &&
+  if source_dir.length() > 0 &&
     source_dir != "." &&
     package_dir.has_prefix(source_dir + "/") {
     package_dir.substring(start=source_dir.length() + 1)
   } else {
     package_dir
-  }
-  if mod_name.length() > 0 {
-    "\{mod_name}/\{relative_path}"
-  } else {
-    relative_path
   }
 }
 

--- a/sol/src/cli/generate.mbt
+++ b/sol/src/cli/generate.mbt
@@ -489,10 +489,13 @@ async fn[FS : @env.FileSystem] run_generate_command_with_fs(
       if island_funcs.is_empty() {
         continue
       }
-      // Construct client package path from moon.mod name + source-stripped path.
-      let client_pkg_path = build_package_path(
+      // MoonBit import path = module name + source-relative package path.
+      // `build_package_path` is source-relative (matches moon's _build layout);
+      // moon.pkg imports still need the full package identity (`mod_name/...`).
+      let client_pkg_rel = build_package_path(
         mod_name, source_dir, island_pattern,
       )
+      let client_pkg_path = "\{mod_name}/\{client_pkg_rel}"
       let client_alias_name = "app_client"
       // Collect export names for __sol_internal__client_* functions only
       let export_names : Array[String] = []


### PR DESCRIPTION
## Problem

`sol build` fails at the bundling step for any project whose `moon.mod`
declares both a `name` and a `source` root:

```
[rolldown] UNRESOLVED_IMPORT: ".../_build/js/release/build/<mod_name>/client/client.js"
```

`build_package_path` (`sol/src/cli/generate.mbt`) prepends the module name to
the package path used in the generated `.sol` client/server stubs, so they
import `_build/js/{profile}/build/{mod_name}/{rel}/{pkg}.js`.

But `moon` emits build artifacts **source-relative** — for a module whose
`source` is `app`, package `app/client` is written to
`_build/js/{profile}/build/client/client.js`, with **no module-name segment**.
The generated stub therefore points at a file that does not exist and bundling
fails.

`moon check` and `moon test` stay green because neither runs the bundler, so
the breakage only shows up on `sol build`. This is a regression against 0.23.0,
which used the source-relative path.

### Reproduce

```jsonc
// moon.mod / moon.mod.json
{ "name": "acme/site", "source": "app", "preferred-target": "js" }
```
with an island under `app/client/` → `moon check` ✅ / `moon test` ✅ /
`sol build` ❌ (unresolved import at `build/acme/site/client/client.js`;
moon actually wrote `build/client/client.js`).

## Fix

Return the source-relative path from `build_package_path` (the module name is
intentionally left unused, kept in the signature for call-site compatibility).
This matches moon's on-disk layout for client, hydrate, and server stubs alike.

Added whitebox tests in `sol/src/cli/build_package_path_wbtest.mbt` pinning the
source-relative behavior. Full `mizchi/sol/cli` suite: **392 passed, 0 failed**.

## Note on the moon layout

Verified against `moon 0.1.20260703` with `rr_moon_mod,rr_moon_pkg` (the flags
this repo's own `moon.work` builds under). If a future moon layout reintroduces
a module-name segment in the build path, a filesystem-probing variant (there is
already `fs.exists_sync` usage nearby) would be more robust than a static
choice — happy to follow up that way if you'd prefer.